### PR TITLE
[SOL][BPF] Disable debug info when solana feature flag is set

### DIFF
--- a/llvm/lib/Target/BPF/BPFTargetMachine.cpp
+++ b/llvm/lib/Target/BPF/BPFTargetMachine.cpp
@@ -74,6 +74,7 @@ BPFTargetMachine::BPFTargetMachine(const Target &T, const Triple &TT,
   BPFMCAsmInfo *MAI =
       static_cast<BPFMCAsmInfo *>(const_cast<MCAsmInfo *>(AsmInfo.get()));
   MAI->setDwarfUsesRelocationsAcrossSections(!Subtarget.getUseDwarfRIS());
+  MAI->setSupportsDebugInformation(!FS.contains("solana"));
 }
 
 namespace {

--- a/llvm/lib/Target/BPF/BTFDebug.cpp
+++ b/llvm/lib/Target/BPF/BTFDebug.cpp
@@ -1082,11 +1082,12 @@ void BTFDebug::beginInstruction(const MachineInstr *MI) {
     // been generated, construct one based on function signature.
     if (LineInfoGenerated == false) {
       auto *S = MI->getMF()->getFunction().getSubprogram();
-      MCSymbol *FuncLabel = Asm->getFunctionBegin();
-      constructLineInfo(S, FuncLabel, S->getLine(), 0);
-      LineInfoGenerated = true;
+      if (S) {
+        MCSymbol *FuncLabel = Asm->getFunctionBegin();
+        constructLineInfo(S, FuncLabel, S->getLine(), 0);
+        LineInfoGenerated = true;
+      }
     }
-
     return;
   }
 

--- a/llvm/lib/Target/BPF/MCTargetDesc/BPFMCAsmInfo.h
+++ b/llvm/lib/Target/BPF/MCTargetDesc/BPFMCAsmInfo.h
@@ -48,6 +48,10 @@ public:
   void setDwarfUsesRelocationsAcrossSections(bool enable) {
     DwarfUsesRelocationsAcrossSections = enable;
   }
+
+  void setSupportsDebugInformation(bool enable) {
+    SupportsDebugInformation = enable;
+  }
 };
 }
 


### PR DESCRIPTION
Solana extends BPF so that structs type information is not fully
supported in BTF.  This leads to ICE crashes and some unsupported
relocations being emitted in binary files that linker errors on.
For, now the debug information is simply disabled when compiling
for Solana to avoid the errors in Debug builds.