### PR TITLE
[SOL] native support for signed division in SBF

### DIFF
--- a/llvm/lib/Target/BPF/BPF.td
+++ b/llvm/lib/Target/BPF/BPF.td
@@ -29,6 +29,9 @@ def FeatureSolana : SubtargetFeature<"solana", "IsSolana", "true",
 def FeatureDynamicFrames : SubtargetFeature<"dynamic-frames", "HasDynamicFrames", "true",
                                             "Enable dynamic frames">;
 
+def FeatureSdiv : SubtargetFeature<"sdiv", "HasSdiv", "true",
+                                   "Enable native BPF_SDIV support">;
+
 class Proc<string Name, list<SubtargetFeature> Features>
  : Processor<Name, NoItineraries, Features>;
 
@@ -37,7 +40,7 @@ def : Proc<"v1", []>;
 def : Proc<"v2", []>;
 def : Proc<"v3", []>;
 def : Proc<"probe", []>;
-def : Proc<"sbfv2", [FeatureSolana, FeatureDynamicFrames]>;
+def : Proc<"sbfv2", [FeatureSolana, FeatureDynamicFrames, FeatureSdiv]>;
 
 def BPFInstPrinter : AsmWriter {
   string AsmWriterClassName  = "InstPrinter";
@@ -52,7 +55,7 @@ def BPFAsmParserVariant : AsmParserVariant {
   int Variant = 0;
   string Name = "BPF";
   string BreakCharacters = ".";
-  string TokenizingCharacters = "#()[]=:.<>!+*";
+  string TokenizingCharacters = "#()[]=:.<>!+*/";
 }
 
 def BPF : Target {

--- a/llvm/lib/Target/BPF/BPFISelDAGToDAG.cpp
+++ b/llvm/lib/Target/BPF/BPFISelDAGToDAG.cpp
@@ -187,16 +187,19 @@ void BPFDAGToDAGISel::Select(SDNode *Node) {
   switch (Opcode) {
   default:
     break;
+
   case ISD::SDIV: {
-    DebugLoc Empty;
-    const DebugLoc &DL = Node->getDebugLoc();
-    if (DL != Empty)
-      errs() << "Error at line " << DL.getLine() << ": ";
-    else
-      errs() << "Error: ";
-    errs() << "Unsupport signed division for DAG: ";
-    Node->print(errs(), CurDAG);
-    errs() << "Please convert to unsigned div/mod.\n";
+    if (!Subtarget->isSolana()) {
+      DebugLoc Empty;
+      const DebugLoc &DL = Node->getDebugLoc();
+      if (DL != Empty)
+        errs() << "Error at line " << DL.getLine() << ": ";
+      else
+        errs() << "Error: ";
+      errs() << "Unsupport signed division for DAG: ";
+      Node->print(errs(), CurDAG);
+      errs() << "\nPlease convert to unsigned div/mod.\n";
+    }
     break;
   }
   case ISD::INTRINSIC_W_CHAIN: {

--- a/llvm/lib/Target/BPF/BPFISelLowering.cpp
+++ b/llvm/lib/Target/BPF/BPFISelLowering.cpp
@@ -124,9 +124,10 @@ BPFTargetLowering::BPFTargetLowering(const TargetMachine &TM,
     if (VT == MVT::i32 && !STI.getHasAlu32())
       continue;
 
-    if (Subtarget->isSolana()) {
+    if (Subtarget->isSolana() && !STI.getHasSdiv()) {
       setOperationAction(ISD::SDIV, VT, Expand);
     }
+
     setOperationAction(ISD::SDIVREM, VT, Expand);
     setOperationAction(ISD::UDIVREM, VT, Expand);
     setOperationAction(ISD::SREM, VT, Expand);

--- a/llvm/lib/Target/BPF/BPFInstrFormats.td
+++ b/llvm/lib/Target/BPF/BPFInstrFormats.td
@@ -43,6 +43,7 @@ def BPF_XOR  : BPFArithOp<0xa>;
 def BPF_MOV  : BPFArithOp<0xb>;
 def BPF_ARSH : BPFArithOp<0xc>;
 def BPF_END  : BPFArithOp<0xd>;
+def BPF_SDIV : BPFArithOp<0xe>;
 
 def BPF_XCHG    : BPFArithOp<0xe>;
 def BPF_CMPXCHG : BPFArithOp<0xf>;

--- a/llvm/lib/Target/BPF/BPFInstrInfo.td
+++ b/llvm/lib/Target/BPF/BPFInstrInfo.td
@@ -287,18 +287,23 @@ multiclass ALU<BPFArithOp Opc, string OpcodeStr, SDNode OpNode> {
 }
 
 let Constraints = "$dst = $src2" in {
-let isAsCheapAsAMove = 1 in {
-  defm ADD : ALU<BPF_ADD, "+=", add>;
-  defm SUB : ALU<BPF_SUB, "-=", sub>;
-  defm OR  : ALU<BPF_OR, "|=", or>;
-  defm AND : ALU<BPF_AND, "&=", and>;
-  defm SLL : ALU<BPF_LSH, "<<=", shl>;
-  defm SRL : ALU<BPF_RSH, ">>=", srl>;
-  defm XOR : ALU<BPF_XOR, "^=", xor>;
-  defm SRA : ALU<BPF_ARSH, "s>>=", sra>;
-}
-  defm MUL : ALU<BPF_MUL, "*=", mul>;
-  defm DIV : ALU<BPF_DIV, "/=", udiv>;
+    let isAsCheapAsAMove = 1 in {
+        defm ADD : ALU<BPF_ADD, "+=", add>;
+        defm SUB : ALU<BPF_SUB, "-=", sub>;
+        defm OR  : ALU<BPF_OR, "|=", or>;
+        defm AND : ALU<BPF_AND, "&=", and>;
+        defm SLL : ALU<BPF_LSH, "<<=", shl>;
+        defm SRL : ALU<BPF_RSH, ">>=", srl>;
+        defm XOR : ALU<BPF_XOR, "^=", xor>;
+        defm SRA : ALU<BPF_ARSH, "s>>=", sra>;
+    }
+
+    defm MUL : ALU<BPF_MUL, "*=", mul>;
+    defm DIV : ALU<BPF_DIV, "/=", udiv>;
+
+    let Predicates = [BPFSubtargetSolana] in {
+        defm SDIV : ALU<BPF_SDIV, "s/=", sdiv>;
+    }
 }
 
 class NEG_RR<BPFOpClass Class, BPFArithOp Opc,

--- a/llvm/lib/Target/BPF/BPFSubtarget.cpp
+++ b/llvm/lib/Target/BPF/BPFSubtarget.cpp
@@ -39,6 +39,7 @@ void BPFSubtarget::initializeEnvironment(const Triple &TT) {
   HasJmp32 = false;
   HasAlu32 = false;
   HasDynamicFrames = false;
+  HasSdiv = false;
   UseDwarfRIS = false;
 }
 

--- a/llvm/lib/Target/BPF/BPFSubtarget.h
+++ b/llvm/lib/Target/BPF/BPFSubtarget.h
@@ -60,6 +60,9 @@ protected:
   // whether we should use fixed or dynamic frames
   bool HasDynamicFrames;
 
+  // whether the cpu supports native BPF_SDIV
+  bool HasSdiv;
+
   // whether we should enable MCAsmInfo DwarfUsesRelocationsAcrossSections
   bool UseDwarfRIS;
 
@@ -79,6 +82,7 @@ public:
   bool getHasJmp32() const { return HasJmp32; }
   bool getHasAlu32() const { return HasAlu32; }
   bool getHasDynamicFrames() const { return HasDynamicFrames; }
+  bool getHasSdiv() const { return HasSdiv; }
   bool getUseDwarfRIS() const { return UseDwarfRIS; }
 
   const BPFInstrInfo *getInstrInfo() const override { return &InstrInfo; }

--- a/llvm/test/CodeGen/BPF/sdiv.ll
+++ b/llvm/test/CodeGen/BPF/sdiv.ll
@@ -1,0 +1,11 @@
+; RUN: llc -march=bpf -mattr=+solana < %s | FileCheck %s -check-prefixes=CHECK-SBF
+; RUN: llc -march=sbf < %s | FileCheck %s -check-prefixes=CHECK-SBF
+; RUN: llc -march=sbf -mcpu=sbfv2 < %s | FileCheck %s -check-prefixes=CHECK-SBFV2
+
+; Function Attrs: norecurse nounwind readnone
+define i32 @test(i32 %len) #0 {
+  %1 = sdiv i32 %len, 15
+; CHECK-SBF: call __divdi3
+; CHECK-SBFV2: r0 s/= 15
+  ret i32 %1
+}

--- a/llvm/test/MC/BPF/sbf-sdiv.s
+++ b/llvm/test/MC/BPF/sbf-sdiv.s
@@ -1,0 +1,15 @@
+# RUN: llvm-mc -triple sbf -filetype=obj -o %t %s
+# RUN: llvm-objdump -d -r %t | FileCheck %s
+
+w1 s/= w2   // BPF_SDIV | BPF_X
+// CHECK: ec 21 00 00 00 00 00 00      w1 s/= w2
+
+w3 s/= 6    // BPF_SDIV | BPF_K
+// CHECK: e4 03 00 00 06 00 00 00      w3 s/= 6
+
+
+r4 s/= r5   // BPF_SDIV | BPF_X
+// CHECK: ef 54 00 00 00 00 00 00 	r4 s/= r5
+
+r5 s/= 6    // BPF_SDIV | BPF_K
+// CHECK: e7 05 00 00 06 00 00 00 	r5 s/= 6


### PR DESCRIPTION
Adds BPF_SDIV, which is enabled only for the SBF subtarget.