### PR TITLE
[SOL] Glue the insn setting $r5 to other in-reg passed args insns

### DIFF
--- a/llvm/lib/Target/BPF/BPFISelLowering.cpp
+++ b/llvm/lib/Target/BPF/BPFISelLowering.cpp
@@ -583,6 +583,8 @@ SDValue BPFTargetLowering::LowerCall(TargetLowering::CallLoweringInfo &CLI,
       llvm_unreachable("call arg pass bug");
   }
 
+  SDValue InFlag;
+
   if (HasStackArgs) {
     SDValue FramePtr = DAG.getCopyFromReg(Chain, CLI.DL, BPF::R10, getPointerTy(MF.getDataLayout()));
 
@@ -603,11 +605,12 @@ SDValue BPFTargetLowering::LowerCall(TargetLowering::CallLoweringInfo &CLI,
       Chain = DAG.getStore(Chain, CLI.DL, Arg, PtrOff, MachinePointerInfo());
     }
 
-    // Pass the current stack frame pointer via BPF::R5
-    Chain = DAG.getCopyToReg(Chain, CLI.DL, BPF::R5, FramePtr);
+    // Pass the current stack frame pointer via BPF::R5, gluing the
+    // instruction to instructions passing the first 4 arguments in
+    // registers below.
+    Chain = DAG.getCopyToReg(Chain, CLI.DL, BPF::R5, FramePtr, InFlag);
+    InFlag = Chain.getValue(1);
   }
-
-  SDValue InFlag;
 
   // Build a sequence of copy-to-reg nodes chained together with token chain and
   // flag operands which copy the outgoing args into registers.  The InFlag is


### PR DESCRIPTION
The actual parameters to a function call are passed in registers for
the first 4 arguments, and on stack for the remaining arguments. The
register $r5 is set to the value of the frame pointer where the actual
parameters are stored. The instruction that copies the frame pointer
into the register $r5 must be glued to the chain of instructions that
sets the previous four call arguments. Otherwise, the scheduler is
free to move the instruction across boundaries of basic blocks and
it's potentially possible that the copy instruction is considered dead
code, even though there's an implicit liveness associated with the
call instruction.