### PR TITLE
[SOL] report exceeded stack size as a warning if dynamic frames are off

### DIFF
--- a/llvm/lib/Target/BPF/BPFRegisterInfo.cpp
+++ b/llvm/lib/Target/BPF/BPFRegisterInfo.cpp
@@ -52,11 +52,24 @@ static void WarnSize(int Offset, MachineFunction &MF, DebugLoc& DL)
   OldMF = &(MF.getFunction());
   int MaxOffset = -1 * BPFRegisterInfo::FrameLength;
   if (Offset <= MaxOffset) {
-    DiagnosticInfoUnsupported DiagStackSize(MF.getFunction(),
-        "BPF stack limit of 512 bytes is exceeded. "
-        "Please move large on stack variables into BPF per-cpu array map.\n",
-        DL);
-    MF.getFunction().getContext().diagnose(DiagStackSize);
+    if (MF.getSubtarget<BPFSubtarget>().isSolana()) {
+      dbgs() << "Error:";
+      if (DL) {
+        dbgs() << " ";
+        DL.print(dbgs());
+      }
+      dbgs() << " Function " << MF.getFunction().getName()
+             << " Stack offset of " << -Offset << " exceeded max offset of "
+             << -MaxOffset << " by " << MaxOffset - Offset
+             << " bytes, please minimize large stack variables\n";
+    } else {
+      DiagnosticInfoUnsupported DiagStackSize(
+          MF.getFunction(),
+          "BPF stack limit of 512 bytes is exceeded. "
+          "Please move large on stack variables into BPF per-cpu array map.\n",
+          DL, DiagnosticSeverity::DS_Error);
+      MF.getFunction().getContext().diagnose(DiagStackSize);
+    }
   }
 }
 


### PR DESCRIPTION
7b107c accidentally reverted it back to an hard error.