### PR TITLE
[SOL] Debug sections relocations

### DIFF
--- a/lld/ELF/Arch/BPF.cpp
+++ b/lld/ELF/Arch/BPF.cpp
@@ -45,6 +45,9 @@ RelExpr BPF::getRelExpr(RelType type, const Symbol &s,
   switch (type) {
     case R_BPF_64_32:
       return R_PC;
+    case R_BPF_64_ABS32:
+    case R_BPF_64_NODYLD32:
+    case R_BPF_64_ABS64:
     case R_BPF_64_64:
       return R_ABS;
     default:
@@ -68,12 +71,26 @@ void BPF::relocate(uint8_t *loc, const Relocation &rel, uint64_t val) const {
       write32le(loc + 4, ((val - 8) / 8) & 0xFFFFFFFF);
       break;
     }
+    case R_BPF_64_ABS32:
+    case R_BPF_64_NODYLD32: {
+      // Relocation used by .BTF.ext and DWARF
+      write32le(loc, val & 0xFFFFFFFF);
+      break;
+    }
     case R_BPF_64_64: {
       // Relocation of a lddw instruction
       // 64 bit address is divided into the imm of this and the following
       // instructions, lower 32 first.
       write32le(loc + 4, val & 0xFFFFFFFF);
       write32le(loc + 8 + 4, val >> 32);
+      break;
+    }
+    case R_BPF_64_ABS64: {
+      // The relocation type is used for normal 64-bit data. The
+      // actual to-be-relocated data is stored at r_offset and the
+      // read/write data bitsize is 64 (8 bytes). The relocation can
+      // be resolved with the symbol value plus implicit addend.
+      write64le(loc, val);
       break;
     }
     default:

--- a/llvm/lib/MC/ELFObjectWriter.cpp
+++ b/llvm/lib/MC/ELFObjectWriter.cpp
@@ -1455,6 +1455,12 @@ void ELFObjectWriter::recordRelocation(MCAssembler &Asm,
     return;
 
   unsigned Type = TargetObjectWriter->getRelocType(Ctx, Target, Fixup, IsPCRel);
+
+  unsigned Flags = FixupSection.getFlags();
+  // Change R_BPF_64_64 relocations in .debug_* sections to R_BPF_64_ABS64 
+  if (Ctx.getTargetTriple().isBPF() && !(Flags & ELF::SHF_ALLOC) && (Type==ELF::R_BPF_64_64))
+      Type = ELF::R_BPF_64_ABS64;  
+
   const auto *Parent = cast<MCSectionELF>(Fragment->getParent());
   // Emiting relocation with sybmol for CG Profile to  help with --cg-profile.
   bool RelocateWithSymbol =

--- a/llvm/lib/Target/BPF/BPFTargetMachine.cpp
+++ b/llvm/lib/Target/BPF/BPFTargetMachine.cpp
@@ -83,8 +83,7 @@ BPFTargetMachine::BPFTargetMachine(const Target &T, const Triple &TT,
   BPFMCAsmInfo *MAI =
       static_cast<BPFMCAsmInfo *>(const_cast<MCAsmInfo *>(AsmInfo.get()));
   MAI->setDwarfUsesRelocationsAcrossSections(!Subtarget.getUseDwarfRIS());
-  bool IsSolana = TT.getArch() == Triple::sbf || FS.contains("solana");
-  MAI->setSupportsDebugInformation(!IsSolana);
+  MAI->setSupportsDebugInformation(true);
 }
 
 namespace {

--- a/llvm/lib/Target/BPF/MCTargetDesc/BPFELFObjectWriter.cpp
+++ b/llvm/lib/Target/BPF/MCTargetDesc/BPFELFObjectWriter.cpp
@@ -92,6 +92,9 @@ unsigned BPFELFObjectWriter::getRelocType(MCContext &Ctx, const MCValue &Target,
           if ((Flags & ELF::SHF_ALLOC) && (Flags & ELF::SHF_WRITE))
             return ELF::R_BPF_64_NODYLD32;
         }
+        // .debug_* sections
+	if (!(Flags & ELF::SHF_ALLOC))
+       	  return ELF::R_BPF_64_ABS32;
       }
     }
     return isSolana ? ELF::R_BPF_64_32 : ELF::R_BPF_64_ABS32;


### PR DESCRIPTION
This is an expansion of #25 

I was discussing with @terorie how we might get complete debug info back in.

After inspecting some objdumps I found `ELF::R_BPF_64_ABS32` relocations in `.debug_*` sections only reference relocatable symbols in other `.debug_*` sections (mostly `.debug_{str, abbrev, frame}`). So these can be filtered by checking the absence of the `ELF::SHF_ALLOC` flag in the target symbol's section header.

`ELF::R_BPF_64_ABS64` in `.debug_*` sections reference symbols in the `.text` section and I couldn't find a fix within `BPFELFObjectWriter::getRelocType()` so I had to resort to the `ELFObjectWriter.cpp` file. I am not sure if this is acceptable since this is a more general `ObjectWriter` used by other Archs as well.

The tests in #25 failed because in the final shared object `.data.rel.ro` (and `.eh_frame` before the recent commit in `solana-labs/rust` to discard it) also have `ELF::R_BPF_64_ABS64` relocations. The fix is identifying all `.debug_*` sections and emitting `ELF::R_BPF_64_ABS64` only for them. This check could be made more explicit with
```c++
FixupSection.getName().startswith(".debug_")
``` 
instead of
```c++
!(Flags & ELF::SHF_ALLOC)
```
 if needed in this line

https://github.com/jawilk/llvm-project/blob/e0ead099cacad6535137b94a5b9fb9880eb4c43a/llvm/lib/MC/ELFObjectWriter.cpp#L1461

After these changes the tests in `solana-labs/solana/programs/bpf` passed for me and I got complete `DWARF` info which I could load successfully into `gdb`.