### PR TITLE
Fix 64 bit relocations in data sections

### DIFF
--- a/lld/ELF/Arch/BPF.cpp
+++ b/lld/ELF/Arch/BPF.cpp
@@ -58,7 +58,18 @@ RelExpr BPF::getRelExpr(RelType type, const Symbol &s,
 }
 
 RelType BPF::getDynRel(RelType type) const {
-  return type;
+  switch (type) {
+    case R_BPF_64_ABS64:
+        // R_BPF_64_ABS64 is symbolic like R_BPF_64_64, which is set as our
+        // symbolicRel in the constructor. Return R_BPF_64_64 here so that if
+        // the symbol isn't preemptible, we emit a _RELATIVE relocation instead
+        // and skip emitting the symbol.
+        //
+        // See https://github.com/solana-labs/llvm-project/blob/6b6aef5dbacef31a3c7b3a54f7f1ba54cafc7077/lld/ELF/Relocations.cpp#L1179
+        return R_BPF_64_64;
+    default:
+        return type;
+  }
 }
 
 int64_t BPF::getImplicitAddend(const uint8_t *buf, RelType type) const {

--- a/llvm/lib/Target/BPF/BPF.td
+++ b/llvm/lib/Target/BPF/BPF.td
@@ -32,6 +32,9 @@ def FeatureDynamicFrames : SubtargetFeature<"dynamic-frames", "HasDynamicFrames"
 def FeatureSdiv : SubtargetFeature<"sdiv", "HasSdiv", "true",
                                    "Enable native BPF_SDIV support">;
 
+def FeatureRelocAbs64 : SubtargetFeature<"reloc-abs64", "UseRelocAbs64", "true",
+                                   "Fix 64bit data relocations">;
+
 class Proc<string Name, list<SubtargetFeature> Features>
  : Processor<Name, NoItineraries, Features>;
 
@@ -40,7 +43,7 @@ def : Proc<"v1", []>;
 def : Proc<"v2", []>;
 def : Proc<"v3", []>;
 def : Proc<"probe", []>;
-def : Proc<"sbfv2", [FeatureSolana, FeatureDynamicFrames, FeatureSdiv]>;
+def : Proc<"sbfv2", [FeatureSolana, FeatureDynamicFrames, FeatureSdiv, FeatureRelocAbs64]>;
 
 def BPFInstPrinter : AsmWriter {
   string AsmWriterClassName  = "InstPrinter";

--- a/llvm/lib/Target/BPF/BPFSubtarget.h
+++ b/llvm/lib/Target/BPF/BPFSubtarget.h
@@ -60,6 +60,9 @@ protected:
   // whether we should use fixed or dynamic frames
   bool HasDynamicFrames;
 
+  // Fixme
+  bool UseRelocAbs64;
+
   // whether the cpu supports native BPF_SDIV
   bool HasSdiv;
 

--- a/llvm/lib/Target/BPF/MCTargetDesc/BPFAsmBackend.cpp
+++ b/llvm/lib/Target/BPF/MCTargetDesc/BPFAsmBackend.cpp
@@ -24,9 +24,10 @@ namespace {
 class BPFAsmBackend : public MCAsmBackend {
 public:
   BPFAsmBackend(support::endianness Endian, const MCSubtargetInfo &STI)
-    : MCAsmBackend(Endian),
-      isSolana(STI.hasFeature(BPF::FeatureSolana) ||
-               STI.getTargetTriple().getArch() == Triple::sbf) {}
+      : MCAsmBackend(Endian),
+        isSolana(STI.hasFeature(BPF::FeatureSolana) ||
+                 STI.getTargetTriple().getArch() == Triple::sbf),
+        relocAbs64(STI.hasFeature(BPF::FeatureRelocAbs64)) {}
   ~BPFAsmBackend() override = default;
 
   void applyFixup(const MCAssembler &Asm, const MCFixup &Fixup,
@@ -47,8 +48,10 @@ public:
   unsigned getNumFixupKinds() const override { return 1; }
 
   bool writeNopData(raw_ostream &OS, uint64_t Count) const override;
+
 private:
   bool isSolana;
+  bool relocAbs64;
 };
 
 } // end anonymous namespace
@@ -98,7 +101,7 @@ void BPFAsmBackend::applyFixup(const MCAssembler &Asm, const MCFixup &Fixup,
 
 std::unique_ptr<MCObjectTargetWriter>
 BPFAsmBackend::createObjectTargetWriter() const {
-  return createBPFELFObjectWriter(0, isSolana);
+  return createBPFELFObjectWriter(0, isSolana, relocAbs64);
 }
 
 MCAsmBackend *llvm::createBPFAsmBackend(const Target &T,

--- a/llvm/lib/Target/BPF/MCTargetDesc/BPFMCTargetDesc.h
+++ b/llvm/lib/Target/BPF/MCTargetDesc/BPFMCTargetDesc.h
@@ -43,9 +43,9 @@ MCAsmBackend *createBPFbeAsmBackend(const Target &T, const MCSubtargetInfo &STI,
                                     const MCRegisterInfo &MRI,
                                     const MCTargetOptions &Options);
 
-std::unique_ptr<MCObjectTargetWriter> createBPFELFObjectWriter(uint8_t OSABI,
-                                                               bool isSolana);
-}
+std::unique_ptr<MCObjectTargetWriter>
+createBPFELFObjectWriter(uint8_t OSABI, bool isSolana, bool useRelocAbs64);
+} // namespace llvm
 
 // Defines symbolic names for BPF registers.  This defines a mapping from
 // register name to register number.

--- a/llvm/test/CodeGen/BPF/reloc-abs64-sbf.ll
+++ b/llvm/test/CodeGen/BPF/reloc-abs64-sbf.ll
@@ -1,0 +1,20 @@
+; RUN: llc -march=sbf -filetype=obj < %s | llvm-objdump -r - | tee -i /tmp/foo | FileCheck --check-prefix=CHECK-RELOC-SBF %s
+; RUN: llc -march=sbf -mcpu=sbfv2 -filetype=obj < %s | llvm-objdump -r - | tee -i /tmp/foo | FileCheck --check-prefix=CHECK-RELOC-SBFv2 %s
+
+@.str = private unnamed_addr constant [25 x i8] c"reloc_64_relative_data.c\00", align 1
+@FILE = dso_local constant i64 ptrtoint ([25 x i8]* @.str to i64), align 8
+
+; Function Attrs: noinline nounwind optnone
+define dso_local i64 @entrypoint(i8* %input) #0 {
+entry:
+  %input.addr = alloca i8*, align 8
+  store i8* %input, i8** %input.addr, align 8
+  %0 = load volatile i64, i64* @FILE, align 8
+  ret i64 %0
+}
+
+; CHECK-RELOC-SBF:   RELOCATION RECORDS FOR [.data.rel.ro]:
+; CHECK-RELOC-SBF:   0000000000000000 R_BPF_64_64 .L.str
+
+; CHECK-RELOC-SBFv2: RELOCATION RECORDS FOR [.data.rel.ro]:
+; CHECK-RELOC-SBFv2: 0000000000000000 R_BPF_64_ABS64 .L.str


### PR DESCRIPTION
Relocate `FK_Data_8` fixups as `R_BPF_64_ABS64`. `R_BPF_64_64` is used for `ldimm64` which only makes sense in `.text`.

Currently 64 bit values in non-text sections get chopped to 32 bits and shifted 32 bits to the left (picture the first 8 bytes of a ldimm64 relocation). This commit fixes it so that 64 bit values get written fully at the intended offset.

For backwards compatibility, the new behaviour is used only if the `reloc-abs64` feature is on (required by `-mcpu=sbfv2`), since rbpf before https://github.com/solana-labs/rbpf/pull/301 assumes the legacy buggy layout.