### PR TITLE
[SOL] revert ABS64 bits of 672d5f8f40ff422ea31571ff2c5f7a65edad7e2e

### DIFF
--- a/llvm/lib/MC/ELFObjectWriter.cpp
+++ b/llvm/lib/MC/ELFObjectWriter.cpp
@@ -1456,11 +1456,6 @@ void ELFObjectWriter::recordRelocation(MCAssembler &Asm,
 
   unsigned Type = TargetObjectWriter->getRelocType(Ctx, Target, Fixup, IsPCRel);
 
-  unsigned Flags = FixupSection.getFlags();
-  // Change R_BPF_64_64 relocations in .debug_* sections to R_BPF_64_ABS64 
-  if (Ctx.getTargetTriple().isBPF() && !(Flags & ELF::SHF_ALLOC) && (Type==ELF::R_BPF_64_64))
-      Type = ELF::R_BPF_64_ABS64;  
-
   const auto *Parent = cast<MCSectionELF>(Fragment->getParent());
   // Emiting relocation with sybmol for CG Profile to  help with --cg-profile.
   bool RelocateWithSymbol =


### PR DESCRIPTION
ABS64 relocs were properly implemented in fb7188bcf651fdaa2d2c522f4b7444e2c574a822