### PR TITLE
sbf: add static-syscalls feature

### DIFF
--- a/llvm/lib/Target/BPF/BPF.td
+++ b/llvm/lib/Target/BPF/BPF.td
@@ -35,6 +35,9 @@ def FeatureSdiv : SubtargetFeature<"sdiv", "HasSdiv", "true",
 def FeatureRelocAbs64 : SubtargetFeature<"reloc-abs64", "UseRelocAbs64", "true",
                                    "Fix 64bit data relocations">;
 
+def FeatureStaticSyscalls : SubtargetFeature<"static-syscalls", "HasStaticSyscalls", "true",
+                                   "Marker feature used for conditional compilation">;
+
 class Proc<string Name, list<SubtargetFeature> Features>
  : Processor<Name, NoItineraries, Features>;
 
@@ -43,7 +46,7 @@ def : Proc<"v1", []>;
 def : Proc<"v2", []>;
 def : Proc<"v3", []>;
 def : Proc<"probe", []>;
-def : Proc<"sbfv2", [FeatureSolana, FeatureDynamicFrames, FeatureSdiv, FeatureRelocAbs64]>;
+def : Proc<"sbfv2", [FeatureSolana, FeatureDynamicFrames, FeatureSdiv, FeatureRelocAbs64, FeatureStaticSyscalls]>;
 
 def BPFInstPrinter : AsmWriter {
   string AsmWriterClassName  = "InstPrinter";

--- a/llvm/lib/Target/BPF/BPFSubtarget.h
+++ b/llvm/lib/Target/BPF/BPFSubtarget.h
@@ -60,11 +60,14 @@ protected:
   // whether we should use fixed or dynamic frames
   bool HasDynamicFrames;
 
-  // Fixme
+  // Relocate FK_Data_8 fixups as R_BPF_64_ABS64
   bool UseRelocAbs64;
 
   // whether the cpu supports native BPF_SDIV
   bool HasSdiv;
+
+  // Not used for anything, just set by the static-syscalls marker feature.
+  bool HasStaticSyscalls;
 
   // whether we should enable MCAsmInfo DwarfUsesRelocationsAcrossSections
   bool UseDwarfRIS;


### PR DESCRIPTION
This adds a marker feature enabled by default by sbfv2. Enables higher layers to change syscall impl depending on whether the feature is set or not.