### PR TITLE
[SOL] Fix callx in AsmParser

### DIFF
--- a/llvm/lib/Target/BPF/AsmParser/BPFAsmParser.cpp
+++ b/llvm/lib/Target/BPF/AsmParser/BPFAsmParser.cpp
@@ -226,6 +226,7 @@ public:
     return StringSwitch<bool>(Name.lower())
         .Case("if", true)
         .Case("call", true)
+        .Case("callx", true)
         .Case("goto", true)
         .Case("*", true)
         .Case("exit", true)


### PR DESCRIPTION
**Problem**

`AsmParser` fails to parse the `callx` instruction.

**Log**

```
% make                                                                             
clang -x assembler -target bpf -march=bpfel+solana -o basic.o basic.s
basic.s:219:9: error: invalid register/token name
        callx r4
        ^
make: *** [basic.o] Error 1
```