### PR TITLE
[SOL] lldb: pretty print instructions

### DIFF
--- a/lldb/include/lldb/Core/Opcode.h
+++ b/lldb/include/lldb/Core/Opcode.h
@@ -9,6 +9,7 @@
 #ifndef LLDB_CORE_OPCODE_H
 #define LLDB_CORE_OPCODE_H
 
+#include "lldb/Utility/ArchSpec.h"
 #include "lldb/Utility/Endian.h"
 #include "lldb/lldb-enumerations.h"
 
@@ -193,7 +194,7 @@ public:
     }
   }
 
-  int Dump(Stream *s, uint32_t min_byte_width);
+  int Dump(Stream *s, uint32_t min_byte_width, const ArchSpec &arch);
 
   const void *GetOpcodeBytes() const {
     return ((m_type == Opcode::eTypeBytes) ? m_data.inst.bytes : nullptr);

--- a/lldb/source/Core/Disassembler.cpp
+++ b/lldb/source/Core/Disassembler.cpp
@@ -596,21 +596,22 @@ void Instruction::Dump(lldb_private::Stream *s, uint32_t max_opcode_byte_size,
   }
 
   if (show_bytes) {
+    ArchSpec arch = exe_ctx->GetTargetPtr()->GetArchitecture();
     if (m_opcode.GetType() == Opcode::eTypeBytes) {
       // x86_64 and i386 are the only ones that use bytes right now so pad out
       // the byte dump to be able to always show 15 bytes (3 chars each) plus a
       // space
       if (max_opcode_byte_size > 0)
-        m_opcode.Dump(&ss, max_opcode_byte_size * 3 + 1);
+        m_opcode.Dump(&ss, max_opcode_byte_size * 3 + 1, arch);
       else
-        m_opcode.Dump(&ss, 15 * 3 + 1);
+        m_opcode.Dump(&ss, 15 * 3 + 1, arch);
     } else {
       // Else, we have ARM or MIPS which can show up to a uint32_t 0x00000000
       // (10 spaces) plus two for padding...
       if (max_opcode_byte_size > 0)
-        m_opcode.Dump(&ss, max_opcode_byte_size * 3 + 1);
+        m_opcode.Dump(&ss, max_opcode_byte_size * 3 + 1, arch);
       else
-        m_opcode.Dump(&ss, 12);
+        m_opcode.Dump(&ss, 12, arch);
     }
   }
 

--- a/lldb/source/Core/Opcode.cpp
+++ b/lldb/source/Core/Opcode.cpp
@@ -21,7 +21,7 @@
 using namespace lldb;
 using namespace lldb_private;
 
-int Opcode::Dump(Stream *s, uint32_t min_byte_width) {
+int Opcode::Dump(Stream *s, uint32_t min_byte_width, const ArchSpec &arch) {
   const uint32_t previous_bytes = s->GetWrittenBytes();
   switch (m_type) {
   case Opcode::eTypeInvalid:
@@ -39,7 +39,15 @@ int Opcode::Dump(Stream *s, uint32_t min_byte_width) {
     break;
 
   case Opcode::eType64:
-    s->Printf("0x%16.16" PRIx64, m_data.inst64);
+    if (arch.IsBPF()) {
+      for (uint32_t i = 0; i < 8; ++i) {
+        if (i > 0)
+          s->PutChar(' ');
+        s->Printf("%2.2x", m_data.inst.bytes[i]);
+      }
+    }
+    else
+      s->Printf("0x%16.16" PRIx64, m_data.inst64);
     break;
 
   case Opcode::eTypeBytes:


### PR DESCRIPTION
Small patch to print an instruction as separated bytes instead of a hex string.

before
```
(lldb) disassemble --name entrypoint -b --count 3
scratch_registers_debug.so`entrypoint:
scratch_registers_debug.so[0x1098] <+0>:  0x0000000000001171       r1     = *(u8 *)(r1 + 0x0)
scratch_registers_debug.so[0x10a0] <+8>:  0xffffffff00001085       call   -0x1
scratch_registers_debug.so[0x10a8] <+16>: 0x0000000000000095       exit
```
after
```
(lldb) disassemble --name entrypoint -b --count 3
scratch_registers_debug.so`entrypoint:
scratch_registers_debug.so[0x1098] <+0>:  71 11 00 00 00 00 00 00  r1     = *(u8 *)(r1 + 0x0)
scratch_registers_debug.so[0x10a0] <+8>:  85 10 00 00 ff ff ff ff  call   -0x1
scratch_registers_debug.so[0x10a8] <+16>: 95 00 00 00 00 00 00 00  exit
```