### PR TITLE
[SOL] lldb: skip ranges with DW_AT_low_pc equal to zero

### DIFF
--- a/lldb/source/Plugins/SymbolFile/DWARF/DWARFDebugAranges.cpp
+++ b/lldb/source/Plugins/SymbolFile/DWARF/DWARFDebugAranges.cpp
@@ -53,7 +53,8 @@ void DWARFDebugAranges::extract(const DWARFDataExtractor &debug_aranges_data) {
         for (uint32_t i = 0; i < num_descriptors; ++i) {
           const DWARFDebugArangeSet::Descriptor &descriptor =
               set.GetDescriptorRef(i);
-          m_aranges.Append(RangeToDIE::Entry(descriptor.address,
+          if (descriptor.address > 0)
+              m_aranges.Append(RangeToDIE::Entry(descriptor.address,
                                              descriptor.length, cu_offset));
         }
       }
@@ -83,7 +84,7 @@ void DWARFDebugAranges::Dump(Log *log) const {
 
 void DWARFDebugAranges::AppendRange(dw_offset_t offset, dw_addr_t low_pc,
                                     dw_addr_t high_pc) {
-  if (high_pc > low_pc)
+  if (high_pc > low_pc && low_pc > 0)
     m_aranges.Append(RangeToDIE::Entry(low_pc, high_pc - low_pc, offset));
 }
 


### PR DESCRIPTION
#### Problem
The `.debug_aranges` section is a lookup table for mapping addresses (pc values) to compilation units. It turns out that some CUs and hence their children's DIEs (e.g. with tag `DW_TAG_subprogram`) have `DW_AT_low_pc == 0x0`. `LLDB` is sorting the aranges table from all CUs from highest to lowest and is combining consecutive values to form ranges (each forming a half-open interval `[DW_AT_low_pc, DW_AT_high_pc)`). When `LLDB` is trying to do a lookup for a function name, it is scanning the sorted aranges table to find the _smallest_ fitting range for a pc value. This is done by narrowing down the ranges till the pc value isn't contained anymore in the next smaller range interval https://github.com/solana-labs/llvm-project/blob/23af211782d5ffbc343ce72bb247bfa2e25d832a/lldb/include/lldb/Utility/RangeMap.h#L534-L535 Having many ranges starting at 0x0 will corrupt this search and we will end up in the wrong CU and consequently get wrong metadata (which leads to wrong source file mapping).
#### Example
Suppose the entrypoint is at `0x6E0` and `LLDB` is maintaining the following range table
<details>
<summary>range table</summary>

```
...   
0x00000000: [0x0 - 0x20)    
0x0009c6a9: [0x0 - 0x5f0)   
0x0000558f: [0x0 - 0x5f8)
0x000e1c66: [0x0 - 0x618)
0x0000558f: [0x0 - 0x698)
0x000e1c66: [0x0 - 0x6c8)
0x0000558f: [0x0 - 0x730)
0x000bca7c: [0x0 - 0x750)
0x000e1c66: [0x0 - 0x760)
0x0000558f: [0x0 - 0x770)
0x000e1c66: [0x0 - 0x778)
0x0000558f: [0x0 - 0x7b8)
0x000e1c66: [0x0 - 0x7c0)
0x0000558f: [0x0 - 0x820)
0x000e1c66: [0x0 - 0x838)
0x0000558f: [0x0 - 0x840)
0x000e1c66: [0x0 - 0x848)
0x0000558f: [0x0 - 0x870)
0x000e1c66: [0x0 - 0x8c0)
0x0000558f: [0x0 - 0x938)
0x000e1c66: [0x0 - 0x9a8)
0x0000558f: [0x0 - 0xa10)
0x000dbc73: [0x0 - 0xa18)
0x0000558f: [0x0 - 0xb68)
0x000e1c66: [0x0 - 0xbb0)
0x0000558f: [0x0 - 0xc88)
0x0009c6a9: [0x0 - 0xcd0)
0x000e1c66: [0x0 - 0xd60)
0x0000558f: [0x0 - 0x10f8)
0x0009c6a9: [0x0 - 0x1258)
0x000bb961: [0x0 - 0x12d0)
0x0000558f: [0x0 - 0x1390)
0x000e1c66: [0x0 - 0x1498)
0x0000558f: [0x0 - 0x24c0)
0x000e1c66: [0x0 - 0x24c0)
0x0000558f: [0x0 - 0x2530)
0x000ae66f: [0x0 - 0x2838)
0x0000558f: [0x0 - 0x7870)
0x000bca7c: [0x0 - 0xf7b0)
0x00000000: [0x120 - 0xc60)
```
</details>

We will match range `0x0000558f [0x0 - 0x730)` instead of the correct one `0x00000000: [0x120 - 0xc60)` and then proceed to search for the `entrypoint` symbol in the wrong CU at offset `0x0000558f`.

#### Solution
Skip all ranges which have `DW_AT_low_pc == 0x0`. This is similar to how [GDB](https://github.com/bminor/binutils-gdb/blob/f15f0ddd10ed6d7c5bc08b3364abef4bd4c8a0f1/gdb/dwarf2/read.c#L13065) is handling it.