### PR TITLE
[SOL] lldb: Add solana-lldb wrapper

### DIFF
--- a/lldb/scripts/solana/lldb_commands
+++ b/lldb/scripts/solana/lldb_commands
@@ -1,0 +1,18 @@
+type synthetic add -l lldb_lookup.synthetic_lookup -x ".*" --category Rust
+type summary add -F lldb_lookup.summary_lookup  -e -x -h "^(alloc::([a-z_]+::)+)String$" --category Rust
+type summary add -F lldb_lookup.summary_lookup  -e -x -h "^&(mut )?str$" --category Rust
+type summary add -F lldb_lookup.summary_lookup  -e -x -h "^&(mut )?\\[.+\\]$" --category Rust
+type summary add -F lldb_lookup.summary_lookup  -e -x -h "^(std::ffi::([a-z_]+::)+)OsString$" --category Rust
+type summary add -F lldb_lookup.summary_lookup  -e -x -h "^(alloc::([a-z_]+::)+)Vec<.+>$" --category Rust
+type summary add -F lldb_lookup.summary_lookup  -e -x -h "^(alloc::([a-z_]+::)+)VecDeque<.+>$" --category Rust
+type summary add -F lldb_lookup.summary_lookup  -e -x -h "^(alloc::([a-z_]+::)+)BTreeSet<.+>$" --category Rust
+type summary add -F lldb_lookup.summary_lookup  -e -x -h "^(alloc::([a-z_]+::)+)BTreeMap<.+>$" --category Rust
+type summary add -F lldb_lookup.summary_lookup  -e -x -h "^(std::collections::([a-z_]+::)+)HashMap<.+>$" --category Rust
+type summary add -F lldb_lookup.summary_lookup  -e -x -h "^(std::collections::([a-z_]+::)+)HashSet<.+>$" --category Rust
+type summary add -F lldb_lookup.summary_lookup  -e -x -h "^(alloc::([a-z_]+::)+)Rc<.+>$" --category Rust
+type summary add -F lldb_lookup.summary_lookup  -e -x -h "^(alloc::([a-z_]+::)+)Arc<.+>$" --category Rust
+type summary add -F lldb_lookup.summary_lookup  -e -x -h "^(core::([a-z_]+::)+)Cell<.+>$" --category Rust
+type summary add -F lldb_lookup.summary_lookup  -e -x -h "^(core::([a-z_]+::)+)Ref<.+>$" --category Rust
+type summary add -F lldb_lookup.summary_lookup  -e -x -h "^(core::([a-z_]+::)+)RefMut<.+>$" --category Rust
+type summary add -F lldb_lookup.summary_lookup  -e -x -h "^(core::([a-z_]+::)+)RefCell<.+>$" --category Rust
+type category enable Rust

--- a/lldb/scripts/solana/lldb_lookup.py
+++ b/lldb/scripts/solana/lldb_lookup.py
@@ -1,0 +1,115 @@
+import lldb
+
+from lldb_providers import *
+from rust_types import RustType, classify_struct, classify_union
+
+
+# BACKCOMPAT: rust 1.35
+def is_hashbrown_hashmap(hash_map):
+    return len(hash_map.type.fields) == 1
+
+
+def classify_rust_type(type):
+    type_class = type.GetTypeClass()
+    if type_class == lldb.eTypeClassStruct:
+        return classify_struct(type.name, type.fields)
+    if type_class == lldb.eTypeClassUnion:
+        return classify_union(type.fields)
+
+    return RustType.OTHER
+
+
+def summary_lookup(valobj, dict):
+    # type: (SBValue, dict) -> str
+    """Returns the summary provider for the given value"""
+    rust_type = classify_rust_type(valobj.GetType())
+
+    if rust_type == RustType.STD_STRING:
+        return StdStringSummaryProvider(valobj, dict)
+    if rust_type == RustType.STD_OS_STRING:
+        return StdOsStringSummaryProvider(valobj, dict)
+    if rust_type == RustType.STD_STR:
+        return StdStrSummaryProvider(valobj, dict)
+
+    if rust_type == RustType.STD_VEC:
+        return SizeSummaryProvider(valobj, dict)
+    if rust_type == RustType.STD_VEC_DEQUE:
+        return SizeSummaryProvider(valobj, dict)
+    if rust_type == RustType.STD_SLICE:
+        return SizeSummaryProvider(valobj, dict)
+
+    if rust_type == RustType.STD_HASH_MAP:
+        return SizeSummaryProvider(valobj, dict)
+    if rust_type == RustType.STD_HASH_SET:
+        return SizeSummaryProvider(valobj, dict)
+
+    if rust_type == RustType.STD_RC:
+        return StdRcSummaryProvider(valobj, dict)
+    if rust_type == RustType.STD_ARC:
+        return StdRcSummaryProvider(valobj, dict)
+
+    if rust_type == RustType.STD_REF:
+        return StdRefSummaryProvider(valobj, dict)
+    if rust_type == RustType.STD_REF_MUT:
+        return StdRefSummaryProvider(valobj, dict)
+    if rust_type == RustType.STD_REF_CELL:
+        return StdRefSummaryProvider(valobj, dict)
+
+    return ""
+
+
+def synthetic_lookup(valobj, dict):
+    # type: (SBValue, dict) -> object
+    """Returns the synthetic provider for the given value"""
+    rust_type = classify_rust_type(valobj.GetType())
+
+    if rust_type == RustType.STRUCT:
+        return StructSyntheticProvider(valobj, dict)
+    if rust_type == RustType.STRUCT_VARIANT:
+        return StructSyntheticProvider(valobj, dict, is_variant=True)
+    if rust_type == RustType.TUPLE:
+        return TupleSyntheticProvider(valobj, dict)
+    if rust_type == RustType.TUPLE_VARIANT:
+        return TupleSyntheticProvider(valobj, dict, is_variant=True)
+    if rust_type == RustType.EMPTY:
+        return EmptySyntheticProvider(valobj, dict)
+    if rust_type == RustType.REGULAR_ENUM:
+        discriminant = valobj.GetChildAtIndex(0).GetChildAtIndex(0).GetValueAsUnsigned()
+        return synthetic_lookup(valobj.GetChildAtIndex(discriminant), dict)
+    if rust_type == RustType.SINGLETON_ENUM:
+        return synthetic_lookup(valobj.GetChildAtIndex(0), dict)
+
+    if rust_type == RustType.STD_VEC:
+        return StdVecSyntheticProvider(valobj, dict)
+    if rust_type == RustType.STD_VEC_DEQUE:
+        return StdVecDequeSyntheticProvider(valobj, dict)
+    if rust_type == RustType.STD_SLICE:
+        return StdSliceSyntheticProvider(valobj, dict)
+
+    if rust_type == RustType.STD_HASH_MAP:
+        if is_hashbrown_hashmap(valobj):
+            return StdHashMapSyntheticProvider(valobj, dict)
+        else:
+            return StdOldHashMapSyntheticProvider(valobj, dict)
+    if rust_type == RustType.STD_HASH_SET:
+        hash_map = valobj.GetChildAtIndex(0)
+        if is_hashbrown_hashmap(hash_map):
+            return StdHashMapSyntheticProvider(valobj, dict, show_values=False)
+        else:
+            return StdOldHashMapSyntheticProvider(hash_map, dict, show_values=False)
+
+    if rust_type == RustType.STD_RC:
+        return StdRcSyntheticProvider(valobj, dict)
+    if rust_type == RustType.STD_ARC:
+        return StdRcSyntheticProvider(valobj, dict, is_atomic=True)
+
+    if rust_type == RustType.STD_CELL:
+        return StdCellSyntheticProvider(valobj, dict)
+    if rust_type == RustType.STD_REF:
+        return StdRefSyntheticProvider(valobj, dict)
+    if rust_type == RustType.STD_REF_MUT:
+        return StdRefSyntheticProvider(valobj, dict)
+    if rust_type == RustType.STD_REF_CELL:
+        return StdRefSyntheticProvider(valobj, dict, is_cell=True)
+
+    return DefaultSynthteticProvider(valobj, dict)

--- a/lldb/scripts/solana/lldb_providers.py
+++ b/lldb/scripts/solana/lldb_providers.py
@@ -1,0 +1,741 @@
+import sys
+
+from lldb import SBValue, SBData, SBError, eBasicTypeLong, eBasicTypeUnsignedLong, \
+    eBasicTypeUnsignedChar
+
+# from lldb.formatters import Logger
+
+####################################################################################################
+# This file contains two kinds of pretty-printers: summary and synthetic.
+#
+# Important classes from LLDB module:
+#   SBValue: the value of a variable, a register, or an expression
+#   SBType:  the data type; each SBValue has a corresponding SBType
+#
+# Summary provider is a function with the type `(SBValue, dict) -> str`.
+#   The first parameter is the object encapsulating the actual variable being displayed;
+#   The second parameter is an internal support parameter used by LLDB, and you should not touch it.
+#
+# Synthetic children is the way to provide a children-based representation of the object's value.
+# Synthetic provider is a class that implements the following interface:
+#
+#     class SyntheticChildrenProvider:
+#         def __init__(self, SBValue, dict)
+#         def num_children(self)
+#         def get_child_index(self, str)
+#         def get_child_at_index(self, int)
+#         def update(self)
+#         def has_children(self)
+#         def get_value(self)
+#
+#
+# You can find more information and examples here:
+#   1. https://lldb.llvm.org/varformats.html
+#   2. https://lldb.llvm.org/python-reference.html
+#   3. https://lldb.llvm.org/python_reference/lldb.formatters.cpp.libcxx-pysrc.html
+#   4. https://github.com/llvm-mirror/lldb/tree/master/examples/summaries/cocoa
+####################################################################################################
+
+PY3 = sys.version_info[0] == 3
+
+
+class ValueBuilder:
+    def __init__(self, valobj):
+        # type: (SBValue) -> ValueBuilder
+        self.valobj = valobj
+        process = valobj.GetProcess()
+        self.endianness = process.GetByteOrder()
+        self.pointer_size = process.GetAddressByteSize()
+
+    def from_int(self, name, value):
+        # type: (str, int) -> SBValue
+        type = self.valobj.GetType().GetBasicType(eBasicTypeLong)
+        data = SBData.CreateDataFromSInt64Array(self.endianness, self.pointer_size, [value])
+        return self.valobj.CreateValueFromData(name, data, type)
+
+    def from_uint(self, name, value):
+        # type: (str, int) -> SBValue
+        type = self.valobj.GetType().GetBasicType(eBasicTypeUnsignedLong)
+        data = SBData.CreateDataFromUInt64Array(self.endianness, self.pointer_size, [value])
+        return self.valobj.CreateValueFromData(name, data, type)
+
+
+def unwrap_unique_or_non_null(unique_or_nonnull):
+    # BACKCOMPAT: rust 1.32
+    # https://github.com/rust-lang/rust/commit/7a0911528058e87d22ea305695f4047572c5e067
+    # BACKCOMPAT: rust 1.60
+    # https://github.com/rust-lang/rust/commit/2a91eeac1a2d27dd3de1bf55515d765da20fd86f
+    ptr = unique_or_nonnull.GetChildMemberWithName("pointer")
+    return ptr if ptr.TypeIsPointerType() else ptr.GetChildAtIndex(0)
+
+
+class DefaultSynthteticProvider:
+    def __init__(self, valobj, dict):
+        # type: (SBValue, dict) -> DefaultSynthteticProvider
+        # logger = Logger.Logger()
+        # logger >> "Default synthetic provider for " + str(valobj.GetName())
+        self.valobj = valobj
+
+    def num_children(self):
+        # type: () -> int
+        return self.valobj.GetNumChildren()
+
+    def get_child_index(self, name):
+        # type: (str) -> int
+        return self.valobj.GetIndexOfChildWithName(name)
+
+    def get_child_at_index(self, index):
+        # type: (int) -> SBValue
+        return self.valobj.GetChildAtIndex(index)
+
+    def update(self):
+        # type: () -> None
+        pass
+
+    def has_children(self):
+        # type: () -> bool
+        return self.valobj.MightHaveChildren()
+
+
+class EmptySyntheticProvider:
+    def __init__(self, valobj, dict):
+        # type: (SBValue, dict) -> EmptySyntheticProvider
+        # logger = Logger.Logger()
+        # logger >> "[EmptySyntheticProvider] for " + str(valobj.GetName())
+        self.valobj = valobj
+
+    def num_children(self):
+        # type: () -> int
+        return 0
+
+    def get_child_index(self, name):
+        # type: (str) -> int
+        return None
+
+    def get_child_at_index(self, index):
+        # type: (int) -> SBValue
+        return None
+
+    def update(self):
+        # type: () -> None
+        pass
+
+    def has_children(self):
+        # type: () -> bool
+        return False
+
+
+def SizeSummaryProvider(valobj, dict):
+    # type: (SBValue, dict) -> str
+    return 'size=' + str(valobj.GetNumChildren())
+
+
+def vec_to_string(vec):
+    length = vec.GetNumChildren()
+    chars = [vec.GetChildAtIndex(i).GetValueAsUnsigned() for i in range(length)]
+    return bytes(chars).decode(errors='replace') if PY3 else "".join(chr(char) for char in chars)
+
+
+def StdStringSummaryProvider(valobj, dict):
+    # type: (SBValue, dict) -> str
+    # logger = Logger.Logger()
+    # logger >> "[StdStringSummaryProvider] for " + str(valobj.GetName())
+    vec = valobj.GetChildAtIndex(0)
+    return '"%s"' % vec_to_string(vec)
+
+
+def StdOsStringSummaryProvider(valobj, dict):
+    # type: (SBValue, dict) -> str
+    # logger = Logger.Logger()
+    # logger >> "[StdOsStringSummaryProvider] for " + str(valobj.GetName())
+    buf = valobj.GetChildAtIndex(0).GetChildAtIndex(0)
+    is_windows = "Wtf8Buf" in buf.type.name
+    vec = buf.GetChildAtIndex(0) if is_windows else buf
+    return '"%s"' % vec_to_string(vec)
+
+
+def StdStrSummaryProvider(valobj, dict):
+    # type: (SBValue, dict) -> str
+    # logger = Logger.Logger()
+    # logger >> "[StdStrSummaryProvider] for " + str(valobj.GetName())
+
+    length = valobj.GetChildMemberWithName("length").GetValueAsUnsigned()
+    if length == 0:
+        return '""'
+
+    data_ptr = valobj.GetChildMemberWithName("data_ptr")
+
+    start = data_ptr.GetValueAsUnsigned()
+    error = SBError()
+    process = data_ptr.GetProcess()
+    data = process.ReadMemory(start, length, error)
+    data = data.decode(encoding='UTF-8') if PY3 else data
+    return '"%s"' % data
+
+
+class StructSyntheticProvider:
+    """Pretty-printer for structs and struct enum variants"""
+
+    def __init__(self, valobj, dict, is_variant=False):
+        # type: (SBValue, dict, bool) -> StructSyntheticProvider
+        # logger = Logger.Logger()
+        self.valobj = valobj
+        self.is_variant = is_variant
+        self.type = valobj.GetType()
+        self.fields = {}
+
+        if is_variant:
+            self.fields_count = self.type.GetNumberOfFields() - 1
+            real_fields = self.type.fields[1:]
+        else:
+            self.fields_count = self.type.GetNumberOfFields()
+            real_fields = self.type.fields
+
+        for number, field in enumerate(real_fields):
+            self.fields[field.name] = number
+
+    def num_children(self):
+        # type: () -> int
+        return self.fields_count
+
+    def get_child_index(self, name):
+        # type: (str) -> int
+        return self.fields.get(name, -1)
+
+    def get_child_at_index(self, index):
+        # type: (int) -> SBValue
+        if self.is_variant:
+            field = self.type.GetFieldAtIndex(index + 1)
+        else:
+            field = self.type.GetFieldAtIndex(index)
+        return self.valobj.GetChildMemberWithName(field.name)
+
+    def update(self):
+        # type: () -> None
+        pass
+
+    def has_children(self):
+        # type: () -> bool
+        return True
+
+
+class TupleSyntheticProvider:
+    """Pretty-printer for tuples and tuple enum variants"""
+
+    def __init__(self, valobj, dict, is_variant=False):
+        # type: (SBValue, dict, bool) -> TupleSyntheticProvider
+        # logger = Logger.Logger()
+        self.valobj = valobj
+        self.is_variant = is_variant
+        self.type = valobj.GetType()
+
+        if is_variant:
+            self.size = self.type.GetNumberOfFields() - 1
+        else:
+            self.size = self.type.GetNumberOfFields()
+
+    def num_children(self):
+        # type: () -> int
+        return self.size
+
+    def get_child_index(self, name):
+        # type: (str) -> int
+        if name.isdigit():
+            return int(name)
+        else:
+            return -1
+
+    def get_child_at_index(self, index):
+        # type: (int) -> SBValue
+        if self.is_variant:
+            field = self.type.GetFieldAtIndex(index + 1)
+        else:
+            field = self.type.GetFieldAtIndex(index)
+        element = self.valobj.GetChildMemberWithName(field.name)
+        return self.valobj.CreateValueFromData(str(index), element.GetData(), element.GetType())
+
+    def update(self):
+        # type: () -> None
+        pass
+
+    def has_children(self):
+        # type: () -> bool
+        return True
+
+
+class StdVecSyntheticProvider:
+    """Pretty-printer for alloc::vec::Vec<T>
+
+    struct Vec<T> { buf: RawVec<T>, len: usize }
+    struct RawVec<T> { ptr: Unique<T>, cap: usize, ... }
+    rust 1.31.1: struct Unique<T: ?Sized> { pointer: NonZero<*const T>, ... }
+    rust 1.33.0: struct Unique<T: ?Sized> { pointer: *const T, ... }
+    rust 1.62.0: struct Unique<T: ?Sized> { pointer: NonNull<T>, ... }
+    struct NonZero<T>(T)
+    struct NonNull<T> { pointer: *const T }
+    """
+
+    def __init__(self, valobj, dict):
+        # type: (SBValue, dict) -> StdVecSyntheticProvider
+        # logger = Logger.Logger()
+        # logger >> "[StdVecSyntheticProvider] for " + str(valobj.GetName())
+        self.valobj = valobj
+        self.update()
+
+    def num_children(self):
+        # type: () -> int
+        return self.length
+
+    def get_child_index(self, name):
+        # type: (str) -> int
+        index = name.lstrip('[').rstrip(']')
+        if index.isdigit():
+            return int(index)
+        else:
+            return -1
+
+    def get_child_at_index(self, index):
+        # type: (int) -> SBValue
+        start = self.data_ptr.GetValueAsUnsigned()
+        address = start + index * self.element_type_size
+        element = self.data_ptr.CreateValueFromAddress("[%s]" % index, address, self.element_type)
+        return element
+
+    def update(self):
+        # type: () -> None
+        self.length = self.valobj.GetChildMemberWithName("len").GetValueAsUnsigned()
+        self.buf = self.valobj.GetChildMemberWithName("buf")
+
+        self.data_ptr = unwrap_unique_or_non_null(self.buf.GetChildMemberWithName("ptr"))
+
+        self.element_type = self.data_ptr.GetType().GetPointeeType()
+        self.element_type_size = self.element_type.GetByteSize()
+
+    def has_children(self):
+        # type: () -> bool
+        return True
+
+
+class StdSliceSyntheticProvider:
+    def __init__(self, valobj, dict):
+        self.valobj = valobj
+        self.update()
+
+    def num_children(self):
+        # type: () -> int
+        return self.length
+
+    def get_child_index(self, name):
+        # type: (str) -> int
+        index = name.lstrip('[').rstrip(']')
+        if index.isdigit():
+            return int(index)
+        else:
+            return -1
+
+    def get_child_at_index(self, index):
+        # type: (int) -> SBValue
+        start = self.data_ptr.GetValueAsUnsigned()
+        address = start + index * self.element_type_size
+        element = self.data_ptr.CreateValueFromAddress("[%s]" % index, address, self.element_type)
+        return element
+
+    def update(self):
+        # type: () -> None
+        self.length = self.valobj.GetChildMemberWithName("length").GetValueAsUnsigned()
+        self.data_ptr = self.valobj.GetChildMemberWithName("data_ptr")
+
+        self.element_type = self.data_ptr.GetType().GetPointeeType()
+        self.element_type_size = self.element_type.GetByteSize()
+
+    def has_children(self):
+        # type: () -> bool
+        return True
+
+
+class StdVecDequeSyntheticProvider:
+    """Pretty-printer for alloc::collections::vec_deque::VecDeque<T>
+
+    struct VecDeque<T> { tail: usize, head: usize, buf: RawVec<T> }
+    """
+
+    def __init__(self, valobj, dict):
+        # type: (SBValue, dict) -> StdVecDequeSyntheticProvider
+        # logger = Logger.Logger()
+        # logger >> "[StdVecDequeSyntheticProvider] for " + str(valobj.GetName())
+        self.valobj = valobj
+        self.update()
+
+    def num_children(self):
+        # type: () -> int
+        return self.size
+
+    def get_child_index(self, name):
+        # type: (str) -> int
+        index = name.lstrip('[').rstrip(']')
+        if index.isdigit() and self.tail <= index and (self.tail + index) % self.cap < self.head:
+            return int(index)
+        else:
+            return -1
+
+    def get_child_at_index(self, index):
+        # type: (int) -> SBValue
+        start = self.data_ptr.GetValueAsUnsigned()
+        address = start + ((index + self.tail) % self.cap) * self.element_type_size
+        element = self.data_ptr.CreateValueFromAddress("[%s]" % index, address, self.element_type)
+        return element
+
+    def update(self):
+        # type: () -> None
+        self.head = self.valobj.GetChildMemberWithName("head").GetValueAsUnsigned()
+        self.tail = self.valobj.GetChildMemberWithName("tail").GetValueAsUnsigned()
+        self.buf = self.valobj.GetChildMemberWithName("buf")
+        self.cap = self.buf.GetChildMemberWithName("cap").GetValueAsUnsigned()
+        if self.head >= self.tail:
+            self.size = self.head - self.tail
+        else:
+            self.size = self.cap + self.head - self.tail
+
+        self.data_ptr = unwrap_unique_or_non_null(self.buf.GetChildMemberWithName("ptr"))
+
+        self.element_type = self.data_ptr.GetType().GetPointeeType()
+        self.element_type_size = self.element_type.GetByteSize()
+
+    def has_children(self):
+        # type: () -> bool
+        return True
+
+
+# BACKCOMPAT: rust 1.35
+class StdOldHashMapSyntheticProvider:
+    """Pretty-printer for std::collections::hash::map::HashMap<K, V, S>
+
+    struct HashMap<K, V, S> {..., table: RawTable<K, V>, ... }
+    struct RawTable<K, V> { capacity_mask: usize, size: usize, hashes: TaggedHashUintPtr, ... }
+    """
+
+    def __init__(self, valobj, dict, show_values=True):
+        # type: (SBValue, dict, bool) -> StdOldHashMapSyntheticProvider
+        self.valobj = valobj
+        self.show_values = show_values
+        self.update()
+
+    def num_children(self):
+        # type: () -> int
+        return self.size
+
+    def get_child_index(self, name):
+        # type: (str) -> int
+        index = name.lstrip('[').rstrip(']')
+        if index.isdigit():
+            return int(index)
+        else:
+            return -1
+
+    def get_child_at_index(self, index):
+        # type: (int) -> SBValue
+        # logger = Logger.Logger()
+        start = self.data_ptr.GetValueAsUnsigned() & ~1
+
+        # See `libstd/collections/hash/table.rs:raw_bucket_at
+        hashes = self.hash_uint_size * self.capacity
+        align = self.pair_type_size
+        # See `libcore/alloc.rs:padding_needed_for`
+        len_rounded_up = (((((hashes + align) % self.modulo - 1) % self.modulo) & ~(
+                (align - 1) % self.modulo)) % self.modulo - hashes) % self.modulo
+        # len_rounded_up = ((hashes + align - 1) & ~(align - 1)) - hashes
+
+        pairs_offset = hashes + len_rounded_up
+        pairs_start = start + pairs_offset
+
+        table_index = self.valid_indices[index]
+        idx = table_index & self.capacity_mask
+        address = pairs_start + idx * self.pair_type_size
+        element = self.data_ptr.CreateValueFromAddress("[%s]" % index, address, self.pair_type)
+        if self.show_values:
+            return element
+        else:
+            key = element.GetChildAtIndex(0)
+            return self.valobj.CreateValueFromData("[%s]" % index, key.GetData(), key.GetType())
+
+    def update(self):
+        # type: () -> None
+        # logger = Logger.Logger()
+
+        self.table = self.valobj.GetChildMemberWithName("table")  # type: SBValue
+        self.size = self.table.GetChildMemberWithName("size").GetValueAsUnsigned()
+        self.hashes = self.table.GetChildMemberWithName("hashes")
+        self.hash_uint_type = self.hashes.GetType()
+        self.hash_uint_size = self.hashes.GetType().GetByteSize()
+        self.modulo = 2 ** self.hash_uint_size
+        self.data_ptr = self.hashes.GetChildAtIndex(0).GetChildAtIndex(0)
+
+        self.capacity_mask = self.table.GetChildMemberWithName("capacity_mask").GetValueAsUnsigned()
+        self.capacity = (self.capacity_mask + 1) % self.modulo
+
+        marker = self.table.GetChildMemberWithName("marker").GetType()  # type: SBType
+        self.pair_type = marker.template_args[0]
+        self.pair_type_size = self.pair_type.GetByteSize()
+
+        self.valid_indices = []
+        for idx in range(self.capacity):
+            address = self.data_ptr.GetValueAsUnsigned() + idx * self.hash_uint_size
+            hash_uint = self.data_ptr.CreateValueFromAddress("[%s]" % idx, address,
+                                                             self.hash_uint_type)
+            hash_ptr = hash_uint.GetChildAtIndex(0).GetChildAtIndex(0)
+            if hash_ptr.GetValueAsUnsigned() != 0:
+                self.valid_indices.append(idx)
+
+        # logger >> "Valid indices: {}".format(str(self.valid_indices))
+
+    def has_children(self):
+        # type: () -> bool
+        return True
+
+
+class StdHashMapSyntheticProvider:
+    """Pretty-printer for hashbrown's HashMap"""
+
+    def __init__(self, valobj, dict, show_values=True):
+        # type: (SBValue, dict, bool) -> StdHashMapSyntheticProvider
+        self.valobj = valobj
+        self.show_values = show_values
+        self.update()
+
+    def num_children(self):
+        # type: () -> int
+        return self.size
+
+    def get_child_index(self, name):
+        # type: (str) -> int
+        index = name.lstrip('[').rstrip(']')
+        if index.isdigit():
+            return int(index)
+        else:
+            return -1
+
+    def get_child_at_index(self, index):
+        # type: (int) -> SBValue
+        pairs_start = self.data_ptr.GetValueAsUnsigned()
+        idx = self.valid_indices[index]
+        if self.new_layout:
+            idx = -(idx + 1)
+        address = pairs_start + idx * self.pair_type_size
+        element = self.data_ptr.CreateValueFromAddress("[%s]" % index, address, self.pair_type)
+        if self.show_values:
+            return element
+        else:
+            key = element.GetChildAtIndex(0)
+            return self.valobj.CreateValueFromData("[%s]" % index, key.GetData(), key.GetType())
+
+    def update(self):
+        # type: () -> None
+        table = self.table()
+        inner_table = table.GetChildMemberWithName("table")
+
+        capacity = inner_table.GetChildMemberWithName("bucket_mask").GetValueAsUnsigned() + 1
+        ctrl = inner_table.GetChildMemberWithName("ctrl").GetChildAtIndex(0)
+
+        self.size = inner_table.GetChildMemberWithName("items").GetValueAsUnsigned()
+        self.pair_type = table.type.template_args[0]
+        if self.pair_type.IsTypedefType():
+            self.pair_type = self.pair_type.GetTypedefedType()
+        self.pair_type_size = self.pair_type.GetByteSize()
+
+        self.new_layout = not inner_table.GetChildMemberWithName("data").IsValid()
+        if self.new_layout:
+            self.data_ptr = ctrl.Cast(self.pair_type.GetPointerType())
+        else:
+            self.data_ptr = inner_table.GetChildMemberWithName("data").GetChildAtIndex(0)
+
+        u8_type = self.valobj.GetTarget().GetBasicType(eBasicTypeUnsignedChar)
+        u8_type_size = self.valobj.GetTarget().GetBasicType(eBasicTypeUnsignedChar).GetByteSize()
+
+        self.valid_indices = []
+        for idx in range(capacity):
+            address = ctrl.GetValueAsUnsigned() + idx * u8_type_size
+            value = ctrl.CreateValueFromAddress("ctrl[%s]" % idx, address,
+                                                u8_type).GetValueAsUnsigned()
+            is_present = value & 128 == 0
+            if is_present:
+                self.valid_indices.append(idx)
+
+    def table(self):
+        # type: () -> SBValue
+        if self.show_values:
+            hashbrown_hashmap = self.valobj.GetChildMemberWithName("base")
+        else:
+            # BACKCOMPAT: rust 1.47
+            # HashSet wraps either std HashMap or hashbrown::HashSet, which both
+            # wrap hashbrown::HashMap, so either way we "unwrap" twice.
+            hashbrown_hashmap = self.valobj.GetChildAtIndex(0).GetChildAtIndex(0)
+        return hashbrown_hashmap.GetChildMemberWithName("table")
+
+    def has_children(self):
+        # type: () -> bool
+        return True
+
+
+def StdRcSummaryProvider(valobj, dict):
+    # type: (SBValue, dict) -> str
+    strong = valobj.GetChildMemberWithName("strong").GetValueAsUnsigned()
+    weak = valobj.GetChildMemberWithName("weak").GetValueAsUnsigned()
+    return "strong={}, weak={}".format(strong, weak)
+
+
+class StdRcSyntheticProvider:
+    """Pretty-printer for alloc::rc::Rc<T> and alloc::sync::Arc<T>
+
+    struct Rc<T> { ptr: NonNull<RcBox<T>>, ... }
+    rust 1.31.1: struct NonNull<T> { pointer: NonZero<*const T> }
+    rust 1.33.0: struct NonNull<T> { pointer: *const T }
+    struct NonZero<T>(T)
+    struct RcBox<T> { strong: Cell<usize>, weak: Cell<usize>, value: T }
+    struct Cell<T> { value: UnsafeCell<T> }
+    struct UnsafeCell<T> { value: T }
+
+    struct Arc<T> { ptr: NonNull<ArcInner<T>>, ... }
+    struct ArcInner<T> { strong: atomic::AtomicUsize, weak: atomic::AtomicUsize, data: T }
+    struct AtomicUsize { v: UnsafeCell<usize> }
+    """
+
+    def __init__(self, valobj, dict, is_atomic=False):
+        # type: (SBValue, dict, bool) -> StdRcSyntheticProvider
+        self.valobj = valobj
+
+        self.ptr = unwrap_unique_or_non_null(self.valobj.GetChildMemberWithName("ptr"))
+
+        self.value = self.ptr.GetChildMemberWithName("data" if is_atomic else "value")
+
+        self.strong = self.ptr.GetChildMemberWithName("strong").GetChildAtIndex(
+            0).GetChildMemberWithName("value")
+        self.weak = self.ptr.GetChildMemberWithName("weak").GetChildAtIndex(
+            0).GetChildMemberWithName("value")
+
+        self.value_builder = ValueBuilder(valobj)
+
+        self.update()
+
+    def num_children(self):
+        # type: () -> int
+        # Actually there are 3 children, but only the `value` should be shown as a child
+        return 1
+
+    def get_child_index(self, name):
+        # type: (str) -> int
+        if name == "value":
+            return 0
+        if name == "strong":
+            return 1
+        if name == "weak":
+            return 2
+        return -1
+
+    def get_child_at_index(self, index):
+        # type: (int) -> SBValue
+        if index == 0:
+            return self.value
+        if index == 1:
+            return self.value_builder.from_uint("strong", self.strong_count)
+        if index == 2:
+            return self.value_builder.from_uint("weak", self.weak_count)
+
+        return None
+
+    def update(self):
+        # type: () -> None
+        self.strong_count = self.strong.GetValueAsUnsigned()
+        self.weak_count = self.weak.GetValueAsUnsigned() - 1
+
+    def has_children(self):
+        # type: () -> bool
+        return True
+
+
+class StdCellSyntheticProvider:
+    """Pretty-printer for std::cell::Cell"""
+
+    def __init__(self, valobj, dict):
+        # type: (SBValue, dict) -> StdCellSyntheticProvider
+        self.valobj = valobj
+        self.value = valobj.GetChildMemberWithName("value").GetChildAtIndex(0)
+
+    def num_children(self):
+        # type: () -> int
+        return 1
+
+    def get_child_index(self, name):
+        # type: (str) -> int
+        if name == "value":
+            return 0
+        return -1
+
+    def get_child_at_index(self, index):
+        # type: (int) -> SBValue
+        if index == 0:
+            return self.value
+        return None
+
+    def update(self):
+        # type: () -> None
+        pass
+
+    def has_children(self):
+        # type: () -> bool
+        return True
+
+
+def StdRefSummaryProvider(valobj, dict):
+    # type: (SBValue, dict) -> str
+    borrow = valobj.GetChildMemberWithName("borrow").GetValueAsSigned()
+    return "borrow={}".format(borrow) if borrow >= 0 else "borrow_mut={}".format(-borrow)
+
+
+class StdRefSyntheticProvider:
+    """Pretty-printer for std::cell::Ref, std::cell::RefMut, and std::cell::RefCell"""
+
+    def __init__(self, valobj, dict, is_cell=False):
+        # type: (SBValue, dict, bool) -> StdRefSyntheticProvider
+        self.valobj = valobj
+
+        borrow = valobj.GetChildMemberWithName("borrow")
+        value = valobj.GetChildMemberWithName("value")
+        if is_cell:
+            self.borrow = borrow.GetChildMemberWithName("value").GetChildMemberWithName("value")
+            self.value = value.GetChildMemberWithName("value")
+        else:
+            self.borrow = borrow.GetChildMemberWithName("borrow").GetChildMemberWithName(
+                "value").GetChildMemberWithName("value")
+            self.value = value.Dereference()
+
+        self.value_builder = ValueBuilder(valobj)
+
+        self.update()
+
+    def num_children(self):
+        # type: () -> int
+        # Actually there are 2 children, but only the `value` should be shown as a child
+        return 1
+
+    def get_child_index(self, name):
+        if name == "value":
+            return 0
+        if name == "borrow":
+            return 1
+        return -1
+
+    def get_child_at_index(self, index):
+        # type: (int) -> SBValue
+        if index == 0:
+            return self.value
+        if index == 1:
+            return self.value_builder.from_int("borrow", self.borrow_count)
+        return None
+
+    def update(self):
+        # type: () -> None
+        self.borrow_count = self.borrow.GetValueAsSigned()
+
+    def has_children(self):
+        # type: () -> bool
+        return True

--- a/lldb/scripts/solana/rust_types.py
+++ b/lldb/scripts/solana/rust_types.py
@@ -1,0 +1,113 @@
+import re
+
+
+class RustType(object):
+    OTHER = "Other"
+    STRUCT = "Struct"
+    TUPLE = "Tuple"
+    CSTYLE_VARIANT = "CStyleVariant"
+    TUPLE_VARIANT = "TupleVariant"
+    STRUCT_VARIANT = "StructVariant"
+    ENUM = "Enum"
+    EMPTY = "Empty"
+    SINGLETON_ENUM = "SingletonEnum"
+    REGULAR_ENUM = "RegularEnum"
+    COMPRESSED_ENUM = "CompressedEnum"
+    REGULAR_UNION = "RegularUnion"
+
+    STD_STRING = "StdString"
+    STD_OS_STRING = "StdOsString"
+    STD_STR = "StdStr"
+    STD_SLICE = "StdSlice"
+    STD_VEC = "StdVec"
+    STD_VEC_DEQUE = "StdVecDeque"
+    STD_BTREE_SET = "StdBTreeSet"
+    STD_BTREE_MAP = "StdBTreeMap"
+    STD_HASH_MAP = "StdHashMap"
+    STD_HASH_SET = "StdHashSet"
+    STD_RC = "StdRc"
+    STD_ARC = "StdArc"
+    STD_CELL = "StdCell"
+    STD_REF = "StdRef"
+    STD_REF_MUT = "StdRefMut"
+    STD_REF_CELL = "StdRefCell"
+
+
+STD_STRING_REGEX = re.compile(r"^(alloc::(\w+::)+)String$")
+STD_STR_REGEX = re.compile(r"^&(mut )?str$")
+STD_SLICE_REGEX = re.compile(r"^&(mut )?\[.+\]$")
+STD_OS_STRING_REGEX = re.compile(r"^(std::ffi::(\w+::)+)OsString$")
+STD_VEC_REGEX = re.compile(r"^(alloc::(\w+::)+)Vec<.+>$")
+STD_VEC_DEQUE_REGEX = re.compile(r"^(alloc::(\w+::)+)VecDeque<.+>$")
+STD_BTREE_SET_REGEX = re.compile(r"^(alloc::(\w+::)+)BTreeSet<.+>$")
+STD_BTREE_MAP_REGEX = re.compile(r"^(alloc::(\w+::)+)BTreeMap<.+>$")
+STD_HASH_MAP_REGEX = re.compile(r"^(std::collections::(\w+::)+)HashMap<.+>$")
+STD_HASH_SET_REGEX = re.compile(r"^(std::collections::(\w+::)+)HashSet<.+>$")
+STD_RC_REGEX = re.compile(r"^(alloc::(\w+::)+)Rc<.+>$")
+STD_ARC_REGEX = re.compile(r"^(alloc::(\w+::)+)Arc<.+>$")
+STD_CELL_REGEX = re.compile(r"^(core::(\w+::)+)Cell<.+>$")
+STD_REF_REGEX = re.compile(r"^(core::(\w+::)+)Ref<.+>$")
+STD_REF_MUT_REGEX = re.compile(r"^(core::(\w+::)+)RefMut<.+>$")
+STD_REF_CELL_REGEX = re.compile(r"^(core::(\w+::)+)RefCell<.+>$")
+
+TUPLE_ITEM_REGEX = re.compile(r"__\d+$")
+
+ENCODED_ENUM_PREFIX = "RUST$ENCODED$ENUM$"
+ENUM_DISR_FIELD_NAME = "<<variant>>"
+
+STD_TYPE_TO_REGEX = {
+    RustType.STD_STRING: STD_STRING_REGEX,
+    RustType.STD_OS_STRING: STD_OS_STRING_REGEX,
+    RustType.STD_STR: STD_STR_REGEX,
+    RustType.STD_SLICE: STD_SLICE_REGEX,
+    RustType.STD_VEC: STD_VEC_REGEX,
+    RustType.STD_VEC_DEQUE: STD_VEC_DEQUE_REGEX,
+    RustType.STD_HASH_MAP: STD_HASH_MAP_REGEX,
+    RustType.STD_HASH_SET: STD_HASH_SET_REGEX,
+    RustType.STD_BTREE_SET: STD_BTREE_SET_REGEX,
+    RustType.STD_BTREE_MAP: STD_BTREE_MAP_REGEX,
+    RustType.STD_RC: STD_RC_REGEX,
+    RustType.STD_ARC: STD_ARC_REGEX,
+    RustType.STD_REF: STD_REF_REGEX,
+    RustType.STD_REF_MUT: STD_REF_MUT_REGEX,
+    RustType.STD_REF_CELL: STD_REF_CELL_REGEX,
+    RustType.STD_CELL: STD_CELL_REGEX,
+}
+
+def is_tuple_fields(fields):
+    # type: (list) -> bool
+    return all(TUPLE_ITEM_REGEX.match(str(field.name)) for field in fields)
+
+
+def classify_struct(name, fields):
+    if len(fields) == 0:
+        return RustType.EMPTY
+
+    for ty, regex in STD_TYPE_TO_REGEX.items():
+        if regex.match(name):
+            return ty
+
+    if fields[0].name == ENUM_DISR_FIELD_NAME:
+        return RustType.ENUM
+
+    if is_tuple_fields(fields):
+        return RustType.TUPLE
+
+    return RustType.STRUCT
+
+
+def classify_union(fields):
+    if len(fields) == 0:
+        return RustType.EMPTY
+
+    first_variant_name = fields[0].name
+    if first_variant_name is None:
+        if len(fields) == 1:
+            return RustType.SINGLETON_ENUM
+        else:
+            return RustType.REGULAR_ENUM
+    elif first_variant_name.startswith(ENCODED_ENUM_PREFIX):
+        assert len(fields) == 1
+        return RustType.COMPRESSED_ENUM
+    else:
+        return RustType.REGULAR_UNION

--- a/lldb/scripts/solana/solana-lldb
+++ b/lldb/scripts/solana/solana-lldb
@@ -1,0 +1,27 @@
+#!/bin/sh
+
+set -e
+
+lldb=./lldb
+if ! command -v "$lldb" > /dev/null; then
+    echo "LLDB not found!" >&2
+    exit 1
+else
+    LLDB_VERSION=$("$lldb" --version | cut -d ' ' -f3)
+
+    if [ "$LLDB_VERSION" = "3.5.0" ]; then
+        cat << EOF >&2
+***
+WARNING: This version of LLDB has known issues with Rust and cannot display the contents of local variables!
+***
+EOF
+    fi
+fi
+
+script_import_rust="command script import \"lldb_lookup.py\""
+script_import_solana="command script import \"solana_lookup.py\""
+commands_file_rust="lldb_commands"
+commands_file_solana="solana_commands"
+
+# Call LLDB with the commands added to the argument list
+"$lldb" --one-line-before-file "$script_import_rust" --one-line-before-file "$script_import_solana" --source-before-file "$commands_file_rust" --source-before-file "$commands_file_solana" "$@"

--- a/lldb/scripts/solana/solana_commands
+++ b/lldb/scripts/solana/solana_commands
@@ -1,0 +1,3 @@
+type summary add -F solana_lookup.summary_lookup solana_program::account_info::AccountInfo --category Solana
+type summary add -F solana_lookup.summary_lookup solana_program::pubkey::Pubkey --category Solana
+type category enable Solana

--- a/lldb/scripts/solana/solana_lookup.py
+++ b/lldb/scripts/solana/solana_lookup.py
@@ -1,0 +1,12 @@
+from solana_providers import *
+from solana_types import SolanaType, classify_solana_type
+
+
+def summary_lookup(valobj, dict):
+    # type: (SBValue, dict) -> str
+    """Returns the summary provider for the given value"""
+    solana_type = classify_solana_type(valobj.GetType())
+    if solana_type == SolanaType.PUBKEY:
+        return PubkeySummaryProvider(valobj, dict)
+    if solana_type == SolanaType.ACCOUNT_INFO:
+        return AccountInfoSummaryProvider(valobj, dict)

--- a/lldb/scripts/solana/solana_providers.py
+++ b/lldb/scripts/solana/solana_providers.py
@@ -1,0 +1,80 @@
+import lldb
+
+
+def encode_b58(num):
+    alphabet = "123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz"
+    b58 = ""
+    while num != 0:
+        b58 += alphabet[num % 58]
+        num //= 58
+    return b58[::-1]
+
+def PubkeySummaryProvider(valobj, internal_dict):
+    err = lldb.SBError()
+    if valobj.TypeIsPointerType():
+        program_id_type = valobj.GetType().GetPointeeType()
+        value = valobj.GetPointeeData()
+    else:
+        value = valobj.GetData()
+    pubkey = [value.GetUnsignedInt8(err, i) for i in range(32)]
+    pubkey = ''.join("{0:0{1}x}".format(i, 2) for i in pubkey)
+    pubkey = encode_b58(int(pubkey, 16))
+
+    if valobj.TypeIsPointerType():
+        return "-> Pubkey = {}".format(pubkey)
+    return "{}".format(pubkey)
+
+
+def AccountInfoSummaryProvider(valobj, internal_dict):
+    err = lldb.SBError()
+    # key
+    key_valobj = valobj.GetChildAtIndex(0)
+
+    # is_signer
+    signer_valobj = valobj.GetChildAtIndex(1)
+
+    # is_writable
+    writable_valobj = valobj.GetChildAtIndex(2)
+
+    # lamports
+    lamport_valobj = valobj.GetChildAtIndex(3)
+    lamport_valobj = lamport_valobj.GetChildAtIndex(0)
+    lamport_valobj = lamport_valobj.GetChildAtIndex(0)
+    lamport_valobj = lamport_valobj.GetChildAtIndex(0)
+    lamports_data = lamport_valobj.GetData();
+    lamports = lamports_data.GetUnsignedInt64(err, 0)
+
+    # data
+    data_valobj = valobj.GetChildAtIndex(4)
+    data_valobj = data_valobj.GetChildAtIndex(0)
+    data_valobj = data_valobj.GetChildAtIndex(0)
+    data_valobj = data_valobj.__str__().replace("value", "data")
+    data_valobj = data_valobj.__str__().replace("  [", "        [")
+    data_valobj = data_valobj.__str__().replace("}", "    }")
+
+    # owner
+    owner_valobj = valobj.GetChildAtIndex(5)
+
+    # executable
+    executable_valobj = valobj.GetChildAtIndex(6)
+
+    # rent_epoch
+    rent_epoch_valobj = valobj.GetChildAtIndex(7)
+    rent_epoch_data = rent_epoch_valobj.GetData();
+    rent_epoch = rent_epoch_data.GetUnsignedInt64(err, 0)
+
+    ret_string = ""
+    if valobj.TypeIsPointerType():
+        ret_string = "-> "
+
+    return ret_string + """{{
+  {}
+  {}
+  {}
+  (u64) lamports = {}
+  {}
+  {}
+  {}
+  (u64) rent_epoch = {}
+}}
+            """.format(key_valobj, signer_valobj, writable_valobj, lamports, owner_valobj, executable_valobj, data_valobj, rent_epoch)

--- a/lldb/scripts/solana/solana_types.py
+++ b/lldb/scripts/solana/solana_types.py
@@ -1,0 +1,19 @@
+import re
+
+
+class SolanaType(object):
+    PUBKEY = "Pubkey"
+    ACCOUNT_INFO = "AccountInfo"
+
+PUBKEY_REGEX = re.compile(r"^(solana_program::pubkey::Pubkey)")
+ACCOUNT_INFO_REGEX = re.compile(r"^(solana_program::account_info::AccountInfo)")
+
+SOLANA_TYPE_TO_REGEX = {
+    SolanaType.PUBKEY: PUBKEY_REGEX,
+    SolanaType.ACCOUNT_INFO: ACCOUNT_INFO_REGEX,
+}
+
+def classify_solana_type(type):
+    for ty, regex in SOLANA_TYPE_TO_REGEX.items():
+        if regex.match(type.name):
+            return ty


### PR DESCRIPTION
Moves https://github.com/solana-labs/rust/pull/67 into `lldb/startup/solana`

This adds a wrapper around the LLDB executable. Once we start to distribute LLDB in sbf-tools, the wrapper + scripts can be put into the same directory as the LLDB executable. Invoking `./solana-lldb` will pre-load helper functions to print rust as well as solana types (e.g. pubkeys in base58 or auto deref of accounts) and then start the LLDB executable.

The original rust scripts are also added in this PR and taken from https://github.com/solana-labs/rust/tree/solana-1.62.0/src/etc as is.