### PR TITLE
Support varargs

### DIFF
--- a/llvm/lib/Target/BPF/BPFISelLowering.h
+++ b/llvm/lib/Target/BPF/BPFISelLowering.h
@@ -84,6 +84,8 @@ private:
   SDValue LowerSELECT_CC(SDValue Op, SelectionDAG &DAG) const;
   SDValue LowerGlobalAddress(SDValue Op, SelectionDAG &DAG) const;
   SDValue LowerATOMICRMW(SDValue Op, SelectionDAG &DAG) const;
+  SDValue LowerVASTART(SDValue Op, SelectionDAG &DAG) const;
+  SDValue LowerVAARG(SDValue Op, SelectionDAG &DAG) const;
 
   // Lower the result values of a call, copying them out of physregs into vregs
   SDValue LowerCallResult(SDValue Chain, SDValue InFlag,

--- a/llvm/lib/Target/BPF/BPFMachineFunctionInfo.h
+++ b/llvm/lib/Target/BPF/BPFMachineFunctionInfo.h
@@ -1,0 +1,26 @@
+#ifndef LLVM_BPF_MACHINE_FUNCTION_INFO_H
+#define LLVM_BPF_MACHINE_FUNCTION_INFO_H
+
+#include "llvm/CodeGen/MachineFunction.h"
+
+namespace llvm {
+
+/// Contains BPF-specific information for each MachineFunction.
+class BPFMachineFunctionInfo : public MachineFunctionInfo {
+  /// FrameIndex for start of varargs area.
+  int VarArgsFrameIndex;
+
+public:
+  BPFMachineFunctionInfo()
+      : VarArgsFrameIndex(0) {}
+
+  explicit BPFMachineFunctionInfo(MachineFunction &MF)
+      : VarArgsFrameIndex(0) {}
+
+  int getVarArgsFrameIndex() const { return VarArgsFrameIndex; }
+  void setVarArgsFrameIndex(int Idx) { VarArgsFrameIndex = Idx; }
+};
+
+} // namespace llvm
+
+#endif // LLVM_BPF_MACHINE_FUNCTION_INFO_H


### PR DESCRIPTION
Adds support for variadic function definitions, `va_start` and `va_arg`

Not expecting this to be merged. This patch doesn't live up to the security standard of the rest of the SBFv2 changes.
Just for myself so I can keep this branch tracked.
And for future reference if anyone's interested.