### PR TITLE
[SOL] Fix bug in LLD that prevented linker from being called twice

### DIFF
--- a/lld/Common/ErrorHandler.cpp
+++ b/lld/Common/ErrorHandler.cpp
@@ -51,6 +51,12 @@ void ErrorHandler::flushStreams() {
   errs().flush();
 }
 
+void ErrorHandler::handleEarlyExit() {
+  if (!exitEarly) {
+    cleanupCallback();
+  }
+}
+
 ErrorHandler &lld::errorHandler() { return context().e; }
 
 raw_ostream &lld::outs() {

--- a/lld/ELF/Driver.cpp
+++ b/lld/ELF/Driver.cpp
@@ -129,6 +129,7 @@ bool elf::link(ArrayRef<const char *> args, llvm::raw_ostream &stdoutOS,
 
   driver->linkerMain(args);
 
+  ctx->e.handleEarlyExit();
   return errorCount() == 0;
 }
 

--- a/lld/MachO/Driver.cpp
+++ b/lld/MachO/Driver.cpp
@@ -1519,5 +1519,6 @@ bool macho::link(ArrayRef<const char *> argsArr, llvm::raw_ostream &stdoutOS,
 
     timeTraceProfilerCleanup();
   }
+  ctx->e.handleEarlyExit();
   return errorCount() == 0;
 }

--- a/lld/include/lld/Common/ErrorHandler.h
+++ b/lld/include/lld/Common/ErrorHandler.h
@@ -116,6 +116,7 @@ public:
   raw_ostream &outs();
   raw_ostream &errs();
   void flushStreams();
+  void handleEarlyExit();
 
   std::unique_ptr<llvm::FileOutputBuffer> outputBuffer;
 


### PR DESCRIPTION
After moving Solang to LLVM 14, an assertion in the linker was failing when we would call it more than once. [This PR](https://github.com/solana-labs/llvm-project/commit/83d59e05b201760e3f364ff6316301d347cbad95#diff-5514d8102381f1f4b47bfb1caf0b7c06bbc3b3d2677c6844d0001eb022b64d88) from the official repository introduced a new data structure `LinkerContext` to manage the error handler and the early exit, but it did not call the `cleanUpCallBack` when we are not exiting the linker early. This PR fixes this bug, so that we can use LLVM 14 on Solang.