### PR TITLE
[SOL] Use ADD for subtracting stack pointer

### DIFF
--- a/llvm/lib/Target/SBF/SBFFrameLowering.cpp
+++ b/llvm/lib/Target/SBF/SBFFrameLowering.cpp
@@ -23,18 +23,16 @@ namespace {
 
 void adjustStackPointer(MachineFunction &MF, MachineBasicBlock &MBB,
                         MachineBasicBlock::iterator &MBBI,
-                        bool Subtract) {
+                        bool IsSubtract) {
   MachineFrameInfo &MFI = MF.getFrameInfo();
   int NumBytes = (int)MFI.getStackSize();
-  if (Subtract)
-    NumBytes = - NumBytes;
   if (NumBytes) {
     DebugLoc Dl;
     const SBFInstrInfo &TII =
         *static_cast<const SBFInstrInfo *>(MF.getSubtarget().getInstrInfo());
     BuildMI(MBB, MBBI, Dl, TII.get(SBF::ADD_ri), SBF::R11)
         .addReg(SBF::R11)
-        .addImm(NumBytes);
+        .addImm(IsSubtract? -NumBytes : NumBytes);
   }
 }
 

--- a/llvm/lib/Target/SBF/SBFFrameLowering.cpp
+++ b/llvm/lib/Target/SBF/SBFFrameLowering.cpp
@@ -22,8 +22,7 @@ using namespace llvm;
 namespace {
 
 void adjustStackPointer(MachineFunction &MF, MachineBasicBlock &MBB,
-                        MachineBasicBlock::iterator &MBBI,
-                        bool IsSubtract) {
+                        MachineBasicBlock::iterator &MBBI, bool IsSubtract) {
   MachineFrameInfo &MFI = MF.getFrameInfo();
   int NumBytes = (int)MFI.getStackSize();
   if (NumBytes) {
@@ -32,7 +31,7 @@ void adjustStackPointer(MachineFunction &MF, MachineBasicBlock &MBB,
         *static_cast<const SBFInstrInfo *>(MF.getSubtarget().getInstrInfo());
     BuildMI(MBB, MBBI, Dl, TII.get(SBF::ADD_ri), SBF::R11)
         .addReg(SBF::R11)
-        .addImm(IsSubtract? -NumBytes : NumBytes);
+        .addImm(IsSubtract ? -NumBytes : NumBytes);
   }
 }
 

--- a/llvm/test/CodeGen/SBF/dynamic_stack_frame_add_not_sub.ll
+++ b/llvm/test/CodeGen/SBF/dynamic_stack_frame_add_not_sub.ll
@@ -1,0 +1,31 @@
+; RUN: llc < %s -march=sbf --mattr=+dynamic-frames | FileCheck %s
+;
+; Source:
+; int test_func(int * vec, int idx) {
+;      vec[idx] = idx-1;
+;      return idx;
+;  }
+; Compilation flag:
+; clang -S -emit-llvm test.c
+
+
+; Function Attrs: noinline nounwind optnone ssp uwtable(sync)
+define i32 @test_func(ptr noundef %vec, i32 noundef %idx) #0 {
+; CHECK-LABEL: test_func:
+; CHECK: add64 r11, -16
+; CHECK: add64 r11, 16
+entry:
+  %vec.addr = alloca ptr, align 8
+  %idx.addr = alloca i32, align 4
+  store ptr %vec, ptr %vec.addr, align 8
+  store i32 %idx, ptr %idx.addr, align 4
+  %0 = load i32, ptr %idx.addr, align 4
+  %sub = sub nsw i32 %0, 1
+  %1 = load ptr, ptr %vec.addr, align 8
+  %2 = load i32, ptr %idx.addr, align 4
+  %idxprom = sext i32 %2 to i64
+  %arrayidx = getelementptr inbounds i32, ptr %1, i64 %idxprom
+  store i32 %sub, ptr %arrayidx, align 4
+  %3 = load i32, ptr %idx.addr, align 4
+  ret i32 %3
+}


### PR DESCRIPTION
This PR replaces `sub r11, imm` by `add r11, -imm` and is the equivalent of https://github.com/solana-labs/rbpf/pull/488 for the SBF target in LLVM.

This is the first task in https://github.com/solana-labs/solana/issues/34250
