### PR TITLE
[SOL] Temporarily disable opt-viewer tests for MacOS.

### DIFF
--- a/lld/test/MachO/compact-unwind-generated.test
+++ b/lld/test/MachO/compact-unwind-generated.test
@@ -1,5 +1,5 @@
 # REQUIRES: x86
-# XFAIL: *
+# XFAIL: system-darwin
 
 # FIXME(gkm): This test is fast on a Release tree, and slow (~10s) on
 # a Debug tree mostly because of llvm-mc. Is there a way to prefer the

--- a/lld/test/MachO/compact-unwind-generated.test
+++ b/lld/test/MachO/compact-unwind-generated.test
@@ -1,4 +1,5 @@
 # REQUIRES: x86
+# XFAIL: *
 
 # FIXME(gkm): This test is fast on a Release tree, and slow (~10s) on
 # a Debug tree mostly because of llvm-mc. Is there a way to prefer the

--- a/llvm/test/tools/opt-viewer/lit.local.cfg
+++ b/llvm/test/tools/opt-viewer/lit.local.cfg
@@ -8,3 +8,6 @@ if 'have_opt_viewer_modules' not in config.available_features:
 # can be resolved.
 if sys.platform == 'win32':
     config.unsupported = True
+
+if sys.platform == 'darwin':
+    config.unsupported = True


### PR DESCRIPTION
These tests currently fail on some Macs for some versions of Python, causing our CI to fail.

See, e.g., https://github.com/llvm/llvm-project/issues/62403 and references therein.