### PR TITLE
[SOL] Add feature flag for the removal of neg and the new semantics of sub

### DIFF
--- a/llvm/lib/Target/SBF/SBF.td
+++ b/llvm/lib/Target/SBF/SBF.td
@@ -38,6 +38,12 @@ def FeatureRelocAbs64 : SubtargetFeature<"reloc-abs64", "UseRelocAbs64", "true",
 def FeatureStaticSyscalls : SubtargetFeature<"static-syscalls", "HasStaticSyscalls", "true",
                                    "Marker feature used for conditional compilation">;
 
+def FeatureDisableNeg : SubtargetFeature<"no-neg", "DisableNeg", "true",
+                                    "Disable the neg instruction">;
+
+def FeatureReverseSubImm : SubtargetFeature<"reverse-sub", "ReverseSubImm", "true",
+                                    "Reverse the operands in the 'sub reg, imm' instruction">;
+
 class Proc<string Name, list<SubtargetFeature> Features>
  : Processor<Name, NoItineraries, Features>;
 
@@ -46,7 +52,8 @@ def : Proc<"v1", []>;
 def : Proc<"v2", []>;
 def : Proc<"v3", []>;
 def : Proc<"probe", []>;
-def : Proc<"sbfv2", [FeatureSolana, FeatureDynamicFrames, FeatureSdiv, FeatureRelocAbs64, FeatureStaticSyscalls]>;
+def : Proc<"sbfv2", [FeatureSolana, FeatureDynamicFrames, FeatureSdiv, FeatureRelocAbs64, FeatureStaticSyscalls,
+                        FeatureDisableNeg, FeatureReverseSubImm]>;
 
 //===----------------------------------------------------------------------===//
 // Assembly printer

--- a/llvm/lib/Target/SBF/SBFInstrInfo.td
+++ b/llvm/lib/Target/SBF/SBFInstrInfo.td
@@ -56,6 +56,10 @@ def SBFNoALU32 : Predicate<"!Subtarget->getHasAlu32()">;
 def SBFSubtargetSolana : Predicate<"Subtarget->isSolana()">;
 def SBFv2 : Predicate<"Subtarget->isSBFv2()">;
 def NoSBFv2 : Predicate<"!Subtarget->isSBFv2()">;
+def SBFHasNeg : Predicate<"!Subtarget->getDisableNeg()">;
+def SBFNoNeg: Predicate<"Subtarget->getDisableNeg()">;
+def SBFRevSub : Predicate<"Subtarget->getReverseSubImm()">;
+def SBFNoRevSub : Predicate<"!Subtarget->getReverseSubImm()">;
 
 def brtarget : Operand<OtherVT> {
   let PrintMethod = "printBrTargetOperand";
@@ -347,14 +351,14 @@ let Constraints = "$dst = $src2" in {
 // In SBFv1, `sub reg, imm` is interpreted as reg = reg - imm,
 // but in SBFv2 it means reg = imm - reg
 def : Pat<(sub GPR:$src, i64immSExt32:$imm),
-          (SUB_ri GPR:$src, i64immSExt32:$imm)>, Requires<[NoSBFv2]>;
+          (SUB_ri GPR:$src, i64immSExt32:$imm)>, Requires<[SBFNoRevSub]>;
 def : Pat<(sub GPR32:$src, i32immSExt32:$imm),
-          (SUB_ri_32 GPR32:$src, i32immSExt32:$imm)>, Requires<[NoSBFv2]>;
+          (SUB_ri_32 GPR32:$src, i32immSExt32:$imm)>, Requires<[SBFNoRevSub]>;
 
 def : Pat<(sub i64immSExt32:$imm, GPR:$src),
-          (SUB_ri GPR:$src, i64immSExt32:$imm)>, Requires<[SBFv2]>;
+          (SUB_ri GPR:$src, i64immSExt32:$imm)>, Requires<[SBFRevSub]>;
 def : Pat<(sub i32immSExt32:$imm, GPR32:$src),
-          (SUB_ri_32 GPR32:$src, i32immSExt32:$imm)>, Requires<[SBFv2]>;
+          (SUB_ri_32 GPR32:$src, i32immSExt32:$imm)>, Requires<[SBFRevSub]>;
 
 class NEG_RR<SBFOpClass Class, SBFArithOp Opc,
              dag outs, dag ins, string asmstr, list<dag> pattern>
@@ -376,11 +380,11 @@ let Constraints = "$dst = $src", isAsCheapAsAMove = 1 in {
 
 // Instruction `neg` exists on SBFv1, but not on SBFv2
 // In SBFv2, the negate operation is done with a subtraction
-def : Pat<(ineg i64:$src), (NEG_64 GPR:$src)>, Requires<[NoSBFv2]>;
-def : Pat<(ineg i32:$src), (NEG_32 GPR32:$src)>, Requires<[NoSBFv2]>;
+def : Pat<(ineg i64:$src), (NEG_64 GPR:$src)>, Requires<[SBFHasNeg]>;
+def : Pat<(ineg i32:$src), (NEG_32 GPR32:$src)>, Requires<[SBFHasNeg]>;
 
-def : Pat<(ineg i64:$src), (SUB_ri GPR:$src, 0)>, Requires<[SBFv2]>;
-def : Pat<(ineg i32:$src), (SUB_ri_32 GPR32:$src, 0)>, Requires<[SBFv2]>;
+def : Pat<(ineg i64:$src), (SUB_ri GPR:$src, 0)>, Requires<[SBFNoNeg]>;
+def : Pat<(ineg i32:$src), (SUB_ri_32 GPR32:$src, 0)>, Requires<[SBFNoNeg]>;
 
 
 class LD_IMM64<bits<4> Pseudo, string Mnemonic>

--- a/llvm/lib/Target/SBF/SBFSubtarget.h
+++ b/llvm/lib/Target/SBF/SBFSubtarget.h
@@ -75,6 +75,13 @@ protected:
   // whether we are targeting SBFv2
   bool IsSBFv2;
 
+  // Whether to disable the negate (neg) instruction
+  bool DisableNeg;
+
+  // Whether to consider 'sub reg, imm' as 'reg = imm - reg', instead of 'reg =
+  // reg - imm'.
+  bool ReverseSubImm;
+
 public:
   // This constructor initializes the data members to match that
   // of the specified triple.
@@ -95,6 +102,8 @@ public:
   bool getHasSdiv() const { return HasSdiv; }
   bool getUseDwarfRIS() const { return UseDwarfRIS; }
   bool isSBFv2() const { return IsSBFv2; }
+  bool getDisableNeg() const { return DisableNeg; }
+  bool getReverseSubImm() const { return ReverseSubImm; }
 
   const SBFInstrInfo *getInstrInfo() const override { return &InstrInfo; }
   const SBFFrameLowering *getFrameLowering() const override {


### PR DESCRIPTION
This is a follow-up to #73. It is better to split the new SBFv2 feature into multiple feature flags, instead of hiding them all behind `--mcpu=sbfv2`. Separate feature flags allow us to test each modification in isolation.
