### PR TITLE
Update ccache version in CI

### DIFF
--- a/.github/workflows/llvm-project-tests.yml
+++ b/.github/workflows/llvm-project-tests.yml
@@ -66,7 +66,7 @@ jobs:
         with:
           fetch-depth: 250
       - name: Setup ccache
-        uses: hendrikmuhs/ccache-action@v1
+        uses: hendrikmuhs/ccache-action@v1.2
         with:
           # A full build of llvm, clang, lld, and lldb takes about 250MB
           # of ccache space. There's not much reason to have more than this,

--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -77,7 +77,7 @@ jobs:
       uses: llvm/actions/install-ninja@main
 
     - name: Setup sccache
-      uses: hendrikmuhs/ccache-action@v1
+      uses: hendrikmuhs/ccache-action@v1.2
       with:
         max-size: 250M
         key: sccache-${{ matrix.os }}-release
@@ -117,7 +117,7 @@ jobs:
         path: ${{ needs.prepare.outputs.build-dir }}/llvm-project
 
     - name: Setup sccache
-      uses: hendrikmuhs/ccache-action@v1
+      uses: hendrikmuhs/ccache-action@v1.2
       with:
         max-size: 250M
         key: sccache-${{ matrix.target.os }}-release


### PR DESCRIPTION
ccache was panicking in this CI run: https://github.com/anza-xyz/llvm-project/actions/runs/8009804015/job/21910510449?pr=87

I updated its version.