### PR TITLE
[SOL] Remove cpu probe

### DIFF
--- a/llvm/lib/Target/SBF/SBFISelLowering.cpp
+++ b/llvm/lib/Target/SBF/SBFISelLowering.cpp
@@ -78,7 +78,7 @@ SBFTargetLowering::SBFTargetLowering(const TargetMachine &TM,
 
   setOperationAction(ISD::INTRINSIC_W_CHAIN, MVT::Other, Custom);
 
-  for (auto VT : {MVT::i8, MVT::i16, MVT::i32, MVT::i32, MVT::i64}) {
+  for (auto VT : {MVT::i8, MVT::i16, MVT::i32, MVT::i64}) {
     if (Subtarget->isSolana()) {
       // Implement custom lowering for all atomic operations
       setOperationAction(ISD::ATOMIC_SWAP, VT, Custom);

--- a/llvm/lib/Target/SBF/SBFSubtarget.cpp
+++ b/llvm/lib/Target/SBF/SBFSubtarget.cpp
@@ -50,13 +50,6 @@ void SBFSubtarget::initializeEnvironment(const Triple &TT) {
 }
 
 void SBFSubtarget::initSubtargetFeatures(StringRef CPU, StringRef FS) {
-  // TODO: jle: This invokes an x86 linux kernel call to probe the eBPF ISA
-  // revision in use. This doesn't seem to make much sense for SBF where we
-  // execute on a VM inside of the Solana runtime, not the VM in the linux
-  // kernel.
-  if (CPU == "probe")
-    CPU = sys::detail::getHostCPUNameForBPF();
-
   ParseSubtargetFeatures(CPU, /*TuneCPU*/ CPU, FS);
 
   if (CPU == "v2") {

--- a/llvm/lib/Target/SBF/SBFTargetFeatures.td
+++ b/llvm/lib/Target/SBF/SBFTargetFeatures.td
@@ -53,7 +53,6 @@ def : Proc<"generic", []>;
 def : Proc<"v1", []>;
 def : Proc<"v2", []>;
 def : Proc<"v3", [ALU32]>;
-def : Proc<"probe", []>;
 def : Proc<"sbfv2", [FeatureSolana, FeatureDynamicFrames, FeatureRelocAbs64, FeatureStaticSyscalls,
                         FeatureDisableNeg, FeatureReverseSubImm, FeatureDisableLddw, FeatureCallxRegSrc,
                           FeaturePqrInstr]>;


### PR DESCRIPTION
The CPU probe is reminiscent from the BPF target and does not make sense for SBF. SBF runs in a virtual machine, whose underlying CPU is not important for the target compilation.