### PR TITLE
[SOL] Workaround sccache failure

### DIFF
--- a/.github/workflows/llvm-project-tests.yml
+++ b/.github/workflows/llvm-project-tests.yml
@@ -43,6 +43,11 @@ jobs:
           # We're using a specific version of macOS due to:
           # https://github.com/actions/virtual-environments/issues/5900
           - macOS-latest
+        include:
+          - compile_cache: sccache
+
+          - compile_cache: ccache
+            os: macos-latest
     steps:
       - name: Setup Windows
         if: startsWith(matrix.os, 'windows')
@@ -65,7 +70,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 250
-      - name: Setup ccache
+      - name: Setup ${{ matrix.compile_cache }}
         uses: hendrikmuhs/ccache-action@v1
         with:
           # A full build of llvm, clang, lld, and lldb takes about 250MB
@@ -76,8 +81,8 @@ jobs:
           # enough cache space for all the tests to run at once and still
           # fit under the 10 GB limit.
           max-size: 500M
-          key: sccache-${{ matrix.os }}
-          variant: sccache
+          key: ${{ matrix.compile_cache }}-${{ matrix.os }}
+          variant: ${{ matrix.compile_cache }}
       - name: Build and Test
         if: "!startsWith(matrix.os, 'windows')"
         uses: llvm/actions/build-test-llvm-project@main
@@ -86,7 +91,7 @@ jobs:
           # This should be a no-op for non-mac OSes
           PKG_CONFIG_PATH: /usr/local/Homebrew/Library/Homebrew/os/mac/pkgconfig//12
         with:
-          cmake_args: '-GNinja -DLLVM_ENABLE_PROJECTS="${{ inputs.projects }}" -DLLVM_EXPERIMENTAL_TARGETS_TO_BUILD="BPF;SBF" -DCMAKE_BUILD_TYPE=Release -DLLDB_INCLUDE_TESTS=OFF -DCMAKE_C_COMPILER_LAUNCHER=sccache -DCMAKE_CXX_COMPILER_LAUNCHER=sccache'
+          cmake_args: '-GNinja -DLLVM_ENABLE_PROJECTS="${{ inputs.projects }}" -DLLVM_EXPERIMENTAL_TARGETS_TO_BUILD="BPF;SBF" -DCMAKE_BUILD_TYPE=Release -DLLDB_INCLUDE_TESTS=OFF -DCMAKE_C_COMPILER_LAUNCHER=${{ matrix.compile_cache }} -DCMAKE_CXX_COMPILER_LAUNCHER=${{ matrix.compile_cache }}'
           build_target:  '${{ inputs.build_target }}'
 
       - name: Build and Test libclc


### PR DESCRIPTION
The macOS failure in the CI is a known issue: https://github.com/mozilla/sccache/issues/2092

This workaround may help until there is a definitive fix.