### PR TITLE
[SOL] Optimize call convention in SBFv2

### DIFF
--- a/llvm/lib/Target/SBF/CMakeLists.txt
+++ b/llvm/lib/Target/SBF/CMakeLists.txt
@@ -34,6 +34,7 @@ add_llvm_target(SBFCodeGen
   SBFMIChecking.cpp
   SBFMISimplifyPatchable.cpp
   BTFDebug.cpp
+  SBFFunctionInfo.cpp
 
   LINK_COMPONENTS
   Analysis

--- a/llvm/lib/Target/SBF/SBFFunctionInfo.cpp
+++ b/llvm/lib/Target/SBF/SBFFunctionInfo.cpp
@@ -1,0 +1,28 @@
+//=- SBFFunctionInfo.cpp - SBF Machine Function Info ---------=//
+
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+///
+/// \file
+/// This file implements SBF-specific per-machine-function
+/// information.
+///
+//===----------------------------------------------------------------------===//
+
+#include "SBFFunctionInfo.h"
+
+namespace llvm {
+
+void SBFFunctionInfo::storeFrameIndexArgument(int FI) {
+  frameIndexes.insert(FI);
+}
+
+bool SBFFunctionInfo::containsFrameIndex(int FI) const {
+  return frameIndexes.find(FI) != frameIndexes.end();
+}
+
+} // namespace llvm

--- a/llvm/lib/Target/SBF/SBFFunctionInfo.h
+++ b/llvm/lib/Target/SBF/SBFFunctionInfo.h
@@ -1,0 +1,32 @@
+//=- SBFFunctionInfo.h - SBF machine function info -*- C++ -*-=//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This file declares SBF-specific per-machine-function information.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_SBFFUNCTIONINFO_H
+#define LLVM_SBFFUNCTIONINFO_H
+
+#include "SBFSubtarget.h"
+#include <unordered_set>
+
+namespace llvm {
+
+class SBFFunctionInfo final : public MachineFunctionInfo {
+  std::unordered_set<int> frameIndexes;
+
+public:
+  SBFFunctionInfo(const Function &F, const SBFSubtarget *STI){};
+
+  void storeFrameIndexArgument(int FI);
+  bool containsFrameIndex(int FI) const;
+};
+} // namespace llvm
+
+#endif // LLVM_SBFFUNCTIONINFO_H

--- a/llvm/lib/Target/SBF/SBFRegisterInfo.h
+++ b/llvm/lib/Target/SBF/SBFRegisterInfo.h
@@ -14,6 +14,7 @@
 #define LLVM_LIB_TARGET_SBF_SBFREGISTERINFO_H
 
 #include "llvm/CodeGen/TargetRegisterInfo.h"
+#include <optional>
 
 #define GET_REGINFO_HEADER
 #include "SBFGenRegisterInfo.inc"
@@ -34,6 +35,9 @@ struct SBFRegisterInfo : public SBFGenRegisterInfo {
                            RegScavenger *RS = nullptr) const override;
 
   Register getFrameRegister(const MachineFunction &MF) const override;
+
+  int resolveInternalFrameIndex(const MachineFunction &MF, int FI,
+                                std::optional<int64_t> Imm) const;
 };
 }
 

--- a/llvm/lib/Target/SBF/SBFSubtarget.cpp
+++ b/llvm/lib/Target/SBF/SBFSubtarget.cpp
@@ -47,6 +47,7 @@ void SBFSubtarget::initializeEnvironment(const Triple &TT) {
   NoLddw = false;
   CallxRegSrc = false;
   HasPqrClass = false;
+  NewCallConvention = false;
 }
 
 void SBFSubtarget::initSubtargetFeatures(StringRef CPU, StringRef FS) {

--- a/llvm/lib/Target/SBF/SBFSubtarget.h
+++ b/llvm/lib/Target/SBF/SBFSubtarget.h
@@ -80,6 +80,9 @@ protected:
   // Whether we have the PQR instruction class
   bool HasPqrClass;
 
+  // Whether to use the new call convention in SBFv2
+  bool NewCallConvention;
+
 public:
   // This constructor initializes the data members to match that
   // of the specified triple.
@@ -102,7 +105,9 @@ public:
   bool getNoLddw() const { return NoLddw; }
   bool getCallXRegSrc() const { return CallxRegSrc; }
   bool getHasPqrClass() const { return HasPqrClass; }
-
+  bool getEnableNewCallConvention() const {
+    return HasDynamicFrames && NewCallConvention;
+  }
   const SBFInstrInfo *getInstrInfo() const override { return &InstrInfo; }
   const SBFFrameLowering *getFrameLowering() const override {
     return &FrameLowering;

--- a/llvm/lib/Target/SBF/SBFTargetFeatures.td
+++ b/llvm/lib/Target/SBF/SBFTargetFeatures.td
@@ -46,6 +46,9 @@ def FeatureCallxRegSrc : SubtargetFeature<"callx-reg-src", "CallxRegSrc", "true"
 def FeaturePqrInstr : SubtargetFeature<"pqr-instr", "HasPqrClass", "true",
                                     "Enable the PQR instruction class">;
 
+def FeatureCallConv : SubtargetFeature<"new-call-conv", "NewCallConvention", "true",
+                                    "Enable new call convetion for SBFv2">;
+
 class Proc<string Name, list<SubtargetFeature> Features>
  : Processor<Name, NoItineraries, Features>;
 
@@ -55,4 +58,4 @@ def : Proc<"v2", []>;
 def : Proc<"v3", [ALU32]>;
 def : Proc<"sbfv2", [FeatureSolana, FeatureDynamicFrames, FeatureRelocAbs64, FeatureStaticSyscalls,
                         FeatureDisableNeg, FeatureReverseSubImm, FeatureDisableLddw, FeatureCallxRegSrc,
-                          FeaturePqrInstr]>;
+                          FeaturePqrInstr, FeatureCallConv]>;

--- a/llvm/lib/Target/SBF/SBFTargetMachine.cpp
+++ b/llvm/lib/Target/SBF/SBFTargetMachine.cpp
@@ -10,9 +10,10 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include "SBFTargetMachine.h"
 #include "SBF.h"
+#include "SBFTargetMachine.h"
 #include "SBFTargetTransformInfo.h"
+#include "SBFFunctionInfo.h"
 #include "MCTargetDesc/SBFMCAsmInfo.h"
 #include "TargetInfo/SBFTargetInfo.h"
 #include "llvm/CodeGen/Passes.h"
@@ -132,6 +133,13 @@ void SBFPassConfig::addIRPasses() {
 TargetTransformInfo
 SBFTargetMachine::getTargetTransformInfo(const Function &F) const {
   return TargetTransformInfo(SBFTTIImpl(this, F));
+}
+
+MachineFunctionInfo *SBFTargetMachine::createMachineFunctionInfo(
+    llvm::BumpPtrAllocator &Allocator, const llvm::Function &F,
+    const llvm::TargetSubtargetInfo *STI) const {
+  return SBFFunctionInfo::create<SBFFunctionInfo>(
+      Allocator, F, static_cast<const SBFSubtarget *>(STI));
 }
 
 // Install an instruction selector pass using

--- a/llvm/lib/Target/SBF/SBFTargetMachine.h
+++ b/llvm/lib/Target/SBF/SBFTargetMachine.h
@@ -42,6 +42,10 @@ public:
   }
 
   void registerPassBuilderCallbacks(PassBuilder &PB) override;
+
+  MachineFunctionInfo *
+  createMachineFunctionInfo(BumpPtrAllocator &Allocator, const Function &F,
+                            const TargetSubtargetInfo *STI) const override;
 };
 }
 

--- a/llvm/test/CodeGen/SBF/many_args_new_conv.ll
+++ b/llvm/test/CodeGen/SBF/many_args_new_conv.ll
@@ -1,0 +1,115 @@
+; RUN: llc -O2 -march=sbf -mcpu=sbfv2 < %s | FileCheck %s
+
+; Function Attrs: nounwind uwtable
+define i32 @caller_no_alloca(i32 %a, i32 %b, i32 %c) #0 {
+entry:
+; CHECK-LABEL: caller_no_alloca
+
+; No changes to the stack pointer
+; CHECK-NOT: add64 r11
+
+; Saving arguments on the stack
+; CHECK: mov64 r4, 55
+; CHECK: stxdw [r10 - 32], r4
+; CHECK: mov64 r4, 60
+; CHECK: stxdw [r10 - 40], r4
+; CHECK: mov64 r4, 50
+; CHECK: stxdw [r10 - 24], r4
+; CHECK: mov64 r4, 4
+; CHECK: stxdw [r10 - 16], r4
+; CHECK: mov64 r4, 3
+; CHECK: stxdw [r10 - 8], r4
+; CHECK: mov64 r4, 1
+; CHECK: mov64 r5, 2
+; CHECK: call callee_alloca
+
+  %call = tail call i32 @callee_alloca(i32 %a, i32 %b, i32 %c, i32 1, i32 2, i32 3, i32 4, i32 50, i32 55, i32 60) #3
+  ret i32 %call
+}
+
+; Function Attrs: nounwind uwtable
+define i32 @caller_alloca(i32 %a, i32 %b, i32 %c) #0 {
+; CHECK-LABEL: caller_alloca
+; CHECK: add64 r11, -24
+; CHECK: ldxw r1, [r10 - 4]
+
+; Saving arguments in the stack
+; CHECK: mov64 r4, 55
+
+; Offset in the callee: (-56) - (-24) = -32
+; CHECK: stxdw [r10 - 56], r4
+; CHECK: mov64 r4, 60
+; Offset in the callee: (-64) - (-24) = -40
+; CHECK: stxdw [r10 - 64], r4
+; CHECK: mov64 r4, 50
+; Offset in the callee: (-48) - (-24) = -24
+; CHECK: stxdw [r10 - 48], r4
+; CHECK: mov64 r4, 4
+; Offset in the callee: (-40) - (-24) = -16
+; CHECK: stxdw [r10 - 40], r4
+; CHECK: mov64 r4, 3
+; Offset in the callee: (-32) - (-24) = -8
+; CHECK: stxdw [r10 - 32], r4
+; CHECK: mov64 r4, 1
+; CHECK: mov64 r5, 2
+; CHECK: call callee_no_alloca
+
+entry:
+  %g = alloca i32
+  %g1 = load i32, ptr %g
+  %call = tail call i32 @callee_no_alloca(i32 %g1, i32 %b, i32 %c, i32 1, i32 2, i32 3, i32 4, i32 50, i32 55, i32 60) #3
+  %h = alloca i128
+  %h1 = load i32, ptr %h
+  %res = sub i32 %call, %h1
+  ret i32 %res
+}
+
+; Function Attrs: nounwind uwtable
+define i32 @callee_alloca(i32 %a, i32 %b, i32 %c, i32 %d, i32 %e, i32 %f, i32 %p, i32 %y, i32 %a1, i32 %a2) #1 {
+; CHECK-LABEL: callee_alloca
+; Loading arguments
+; CHECK: ldxdw r2, [r10 - 8]
+; CHECK: ldxdw r2, [r10 - 16]
+; CHECK: ldxdw r2, [r10 - 24]
+; CHECK: ldxdw r2, [r10 - 32]
+; CHECK: ldxdw r2, [r10 - 40]
+; Loading allocated i32
+; CHECK: ldxw r0, [r10 - 44]
+
+entry:
+  %o = alloca i32
+  %g = add i32 %a, %b
+  %h = sub i32 %g, %c
+  %i = add i32 %h, %d
+  %j = sub i32 %i, %e
+  %k = add i32 %j, %f
+  %l = add i32 %k, %p
+  %m = add i32 %l, %y
+  %n = add i32 %m, %a1
+  %q = add i32 %n, %a2
+  %r = load i32, ptr %o
+  %s = add i32 %r, %q
+  ret i32 %s
+}
+
+; Function Attrs: nounwind uwtable
+define i32 @callee_no_alloca(i32 %a, i32 %b, i32 %c, i32 %d, i32 %e, i32 %f, i32 %p, i32 %y, i32 %a1, i32 %a2) #1 {
+; CHECK-LABEL: callee_no_alloca
+; Loading arguments
+; CHECK: ldxdw r1, [r10 - 8]
+; CHECK: ldxdw r1, [r10 - 16]
+; CHECK: ldxdw r1, [r10 - 24]
+; CHECK: ldxdw r1, [r10 - 32]
+; CHECK: ldxdw r1, [r10 - 40]
+entry:
+  %g = add i32 %a, %b
+  %h = sub i32 %g, %c
+  %i = add i32 %h, %d
+  %j = sub i32 %i, %e
+  %k = add i32 %j, %f
+  %l = add i32 %k, %p
+  %m = add i32 %l, %y
+  %n = add i32 %m, %a1
+  %q = add i32 %n, %a2
+  ret i32 %q
+}

--- a/llvm/test/CodeGen/SBF/stack_args_v2.ll
+++ b/llvm/test/CodeGen/SBF/stack_args_v2.ll
@@ -1,4 +1,4 @@
-; RUN: llc -O2 -march=sbf -mcpu=sbfv2 < %s | FileCheck %s
+; RUN: llc -O2 -march=sbf -mattr=+dynamic-frames < %s | FileCheck %s
 
 ; Function Attrs: nounwind uwtable
 define i32 @foo(i32 %a, i32 %b, i32 %c) #0 {


### PR DESCRIPTION
**Problem**

SBFv2 introduces dynamic frame sizes without stack gaps, so that we know during compile time the frame size for a function. As a consequence, the call convention inherited from SBFv1 in https://github.com/anza-xyz/llvm-project/pull/84 becomes inefficient.

If there are more than five arguments in a function call in the old convention, we do:
1. Store four arguments in the registers.
2. Store the remaining arguments in the caller's frame, starting at the frame's higher address.
3. Copy the frame pointer to R5: `mov r5, r10`
4. Access the arguments in the callee using R5.

We are clobbering R5 unnecessarily in this scheme.

**Solution**

This PR introduces a new call convention for SBFv2, leveraging the dynamic stack frames.

In the new convention, we do the following:
1. Store five arguments in the registers (from r1 to r5).
2. Store the remaining arguments in the callee's frame, starting at the higher address.
3. Access the arguments in the callee using the frame pointer R10.

In this case, we free up one general purpose register and reduce one load and one store from function calls.