### PR TITLE
[SOL] Do not miss stack size errors

### DIFF
--- a/llvm/lib/Target/SBF/SBFRegisterInfo.cpp
+++ b/llvm/lib/Target/SBF/SBFRegisterInfo.cpp
@@ -46,12 +46,14 @@ BitVector SBFRegisterInfo::getReservedRegs(const MachineFunction &MF) const {
 static void WarnSize(int Offset, MachineFunction &MF, DebugLoc& DL)
 {
   static Function *OldMF = nullptr;
-  if (&(MF.getFunction()) == OldMF) {
-    return;
-  }
-  OldMF = &(MF.getFunction());
   int MaxOffset = -1 * SBFRegisterInfo::FrameLength;
   if (Offset <= MaxOffset) {
+
+    if (&(MF.getFunction()) == OldMF) {
+      return;
+    }
+    OldMF = &(MF.getFunction());
+
     if (MF.getSubtarget<SBFSubtarget>().isSolana()) {
       dbgs() << "Error:";
       if (DL) {


### PR DESCRIPTION
**Problem**

We emit errors for functions that access offsets outside their stack frame and avoid emitting duplicate error for the same functions. The code for duplicate detection was misplaced and missed errors from many cases. For instance, if a function first accesses offset 40, it would be marked as seen, but it could later access offset 4122 (out of its stack) without errors.

**Changes**

I put the duplicate detection code in the right place. This PR is a stop gap until I complete a major refactoring in this error as described in https://github.com/anza-xyz/agave/issues/1729. I thought it would be good to have this in before a compiler release.