### PR TITLE
[SOL] Inform stack size in error message

### DIFF
--- a/llvm/lib/Target/SBF/SBFRegisterInfo.cpp
+++ b/llvm/lib/Target/SBF/SBFRegisterInfo.cpp
@@ -60,10 +60,12 @@ static void WarnSize(int Offset, MachineFunction &MF, DebugLoc& DL)
         dbgs() << " ";
         DL.print(dbgs());
       }
+      uint64_t StackSize = MF.getFrameInfo().getStackSize();
       dbgs() << " Function " << MF.getFunction().getName()
              << " Stack offset of " << -Offset << " exceeded max offset of "
              << -MaxOffset << " by " << MaxOffset - Offset
-             << " bytes, please minimize large stack variables\n";
+             << " bytes, please minimize large stack variables. "
+             << "Estimated function frame size: " << StackSize << " bytes.\n\n";
     } else {
       DiagnosticInfoUnsupported DiagStackSize(
           MF.getFunction(),


### PR DESCRIPTION
**Problem**

The error message when a function accesses an offset greater than allowed does not inform the function frame size, hindering debugging. It only shows one of the accessed offsets, which is not necessarily the greatest one.

**Solution**

Inform the estimated frame size for that function.