### PR TITLE
[SOL] Better sBPFv1 sign extension

### DIFF
--- a/llvm/lib/Target/SBF/SBFISelLowering.cpp
+++ b/llvm/lib/Target/SBF/SBFISelLowering.cpp
@@ -1023,6 +1023,19 @@ SBFTargetLowering::EmitSubregExt(MachineInstr &MI, MachineBasicBlock *BB,
     BuildMI(BB, DL, TII.get(SBF::MOV_32_64), PromotedReg0).addReg(Reg);
     return PromotedReg0;
   }
+
+  if (Subtarget->isSolana()) {
+    const TargetRegisterClass *RC32 = getRegClassFor(MVT::i32);
+    Register Reg0 = RegInfo.createVirtualRegister(RC32);
+    Register PromotedReg0 = RegInfo.createVirtualRegister(RC);
+    BuildMI(BB, DL, TII.get(SBF::ADD_ri_32), Reg0).addReg(Reg).addImm(0);
+    BuildMI(BB, DL, TII.get(SBF::SUBREG_TO_REG), PromotedReg0)
+        .addImm(0)
+        .addReg(Reg0)
+        .addImm(SBF::sub_32);
+    return PromotedReg0;
+  }
+
   Register PromotedReg0 = RegInfo.createVirtualRegister(RC);
   Register PromotedReg1 = RegInfo.createVirtualRegister(RC);
   Register PromotedReg2 = RegInfo.createVirtualRegister(RC);

--- a/llvm/lib/Target/SBF/SBFInstrInfo.td
+++ b/llvm/lib/Target/SBF/SBFInstrInfo.td
@@ -969,7 +969,7 @@ def : Pat<(SBFWrapper tglobaladdr:$in),
 
 
 def : Pat<(i64 (sext GPR32:$src)),
-          (SRA_ri (SLL_ri (MOV_32_64 GPR32:$src), 32), 32)>;
+          (SUBREG_TO_REG (i64 0), (ADD_ri_32 GPR32:$src, 0), sub_32)>;
 
 def : Pat<(i64 (zext GPR32:$src)), (MOV_32_64 GPR32:$src)>;
 

--- a/llvm/test/CodeGen/SBF/32-bit-subreg-peephole.ll
+++ b/llvm/test/CodeGen/SBF/32-bit-subreg-peephole.ll
@@ -73,8 +73,7 @@ define dso_local i64 @select_s(i32 %a, i32 %b, i64 %c, i64 %d) local_unnamed_add
 entry:
   %cmp = icmp sgt i32 %a, %b
   %c.d = select i1 %cmp, i64 %c, i64 %d
-; CHECK: lsh64 r{{[0-9]+}}, 32
-; CHECK-NEXT: arsh64 r{{[0-9]+}}, 32
+; CHECK: add32 w{{[0-9]+}}, 0
 ; CHECK: {{jslt|jsgt}} r{{[0-9]+}}, r{{[0-9]+}},
   ret i64 %c.d
 }
@@ -117,8 +116,7 @@ entry:
   %cmp = icmp sgt i32 %call, 6
 ; The shifts can't be optimized out because %call comes from function call
 ; return i32 so the high bits might be invalid.
-; CHECK: lsh64 r{{[0-9]+}}, 32
-; CHECK-NEXT: arsh64 r{{[0-9]+}}, 32
+; CHECK: add32 w{{[0-9]+}}, 0
   %cond = zext i1 %cmp to i32
 ; CHECK: {{jslt|jsgt}} r{{[0-9]+}}, {{[0-9]+}},
   ret i32 %cond

--- a/llvm/test/CodeGen/SBF/atomics_sbf.ll
+++ b/llvm/test/CodeGen/SBF/atomics_sbf.ll
@@ -181,12 +181,10 @@ entry:
 
 ; CHECK-LABEL: test_min_32
 ; CHECK: ldxw w0, [r1 + 0]
-; CHECK: mov64 r4, r0
-; CHECK: lsh64 r4, 32
-; CHECK: arsh64 r4, 32
-; CHECK: mov32 r5, w2
-; CHECK: lsh64 r5, 32
-; CHECK: arsh64 r5, 32
+; CHECK: mov32 w4, w0
+; CHECK-NEXT: add32 w4, 0
+; CHECK: mov32 w5, w2
+; CHECK-NEXT: add32 w5, 0
 ; CHECK: mov32 w3, w0
 ; CHECK: jslt r4, r5, LBB16_2
 ; CHECK: mov32 w3, w2
@@ -211,12 +209,10 @@ entry:
 
 ; CHECK-LABEL: test_max_32
 ; CHECK: ldxw w0, [r1 + 0]
-; CHECK: mov64 r4, r0
-; CHECK: lsh64 r4, 32
-; CHECK: arsh64 r4, 32
-; CHECK: mov32 r5, w2
-; CHECK: lsh64 r5, 32
-; CHECK: arsh64 r5, 32
+; CHECK: mov32 w4, w0
+; CHECK-NEXT: add32 w4, 0
+; CHECK: mov32 w5, w2
+; CHECK-NEXT: add32 w5, 0
 ; CHECK: mov32 w3, w0
 ; CHECK: jsgt r4, r5, LBB18_2
 ; CHECK: mov32 w3, w2

--- a/llvm/test/CodeGen/SBF/loop-exit-cond.ll
+++ b/llvm/test/CodeGen/SBF/loop-exit-cond.ll
@@ -49,11 +49,10 @@ for.cond:                                         ; preds = %for.inc, %if.then
   %cmp1 = icmp slt i32 %2, %3
   br i1 %cmp1, label %for.body, label %for.cond.cleanup
 
-; CHECK:      mov32 r[[LEN:[0-9]+]], w1
-; CHECK:      add32 w[[IDX32:[0-9]+]], 1
-; CHECK:      mov64 r[[IDX:[0-9]+]], r[[IDX32:[0-9]+]]
-; CHECK:      lsh64 r[[IDX:[0-9]+]], 32
-; CHECK:      arsh64 r[[IDX:[0-9]+]], 32
+; CHECK:      mov32 w[[LEN32:[0-9]+]], w1
+; CHECK:      add32 w[[IDX:[0-9]+]], 1
+; CHECK:      mov32 w[[LEN:[0-9]+]], w[[LEN32]]
+; CHECK:      add32 w[[LEN]], 0
 ; CHECK-NEXT: jslt r[[IDX]], r[[LEN]],
 
 for.cond.cleanup:                                 ; preds = %for.cond


### PR DESCRIPTION
Using "add32 reg, 0" for sign extension is more efficient than using "lsh reg, 32; arsh reg 32".

- [ ] Write lit tests
- [ ] Make sure Rust still compiles and tests pass
- [ ] Verify if codegen improved for real Solana programs

[_631ee818051efc6985667197-LLVM sBPF sign-extend optimzation-040724-143334.pdf](https://github.com/user-attachments/files/16100234/_631ee818051efc6985667197-LLVM.sBPF.sign-extend.optimzation-040724-143334.pdf)
