### PR TITLE
[SOL] Error out when we overwrite data during function call

### DIFF
--- a/llvm/test/CodeGen/SBF/func_call_error.ll
+++ b/llvm/test/CodeGen/SBF/func_call_error.ll
@@ -1,0 +1,46 @@
+; RUN: not --crash llc < %s -march=sbf 2>&1 | FileCheck %s
+
+; Function Attrs: noinline nounwind optnone ssp uwtable(sync)
+define i32 @func(i32 noundef %0, i32 noundef %1, i32 noundef %2, i32 noundef %3, i32 noundef %4, i32 noundef %5) #0 {
+  ret i32 %2
+}
+
+; Function Attrs: noinline nounwind optnone ssp uwtable(sync)
+define i32 @func1(i32 noundef %0, i32 noundef %1, i32 noundef %2, i32 noundef %3) #0 {
+  %5 = alloca i32, align 4
+  %6 = alloca i32, align 4
+  %7 = alloca i32, align 4
+  %8 = alloca i32, align 4
+  %9 = alloca [4070 x i8], align 1
+  store i32 %0, ptr %5, align 4
+  store i32 %1, ptr %6, align 4
+  store i32 %2, ptr %7, align 4
+  store i32 %3, ptr %8, align 4
+  %10 = load i32, ptr %5, align 4
+  %11 = load i32, ptr %6, align 4
+  %12 = load i32, ptr %7, align 4
+  %13 = load i32, ptr %8, align 4
+  %14 = getelementptr inbounds [4070 x i8], ptr %9, i64 0, i64 5
+  %15 = load i8, ptr %14, align 1
+  %16 = sext i8 %15 to i32
+  %17 = getelementptr inbounds [4070 x i8], ptr %9, i64 0, i64 9
+  %18 = load i8, ptr %17, align 1
+  %19 = sext i8 %18 to i32
+  %20 = call i32 @func(i32 noundef %10, i32 noundef %11, i32 noundef %12, i32 noundef %13, i32 noundef %16, i32 noundef %19)
+  ret i32 %20
+
+; CHECK: A function call in method func1 overwrites values in the frame.
+; CHECK: Please, decrease stack usage or remove parameters from the call.
+; CHECK: The function call may cause undefined behavior during execution.
+}
+
+
+attributes #0 = { noinline nounwind optnone ssp uwtable(sync) "frame-pointer"="non-leaf" "min-legal-vector-width"="0" "no-trapping-math"="true" "probe-stack"="__chkstk_darwin" "stack-protector-buffer-size"="8" "target-cpu"="apple-m1" "target-features"="+aes,+crc,+crypto,+dotprod,+fp-armv8,+fp16fml,+fullfp16,+lse,+neon,+ras,+rcpc,+rdm,+sha2,+sha3,+sm4,+v8.1a,+v8.2a,+v8.3a,+v8.4a,+v8.5a,+v8a,+zcm,+zcz" }
+
+!llvm.module.flags = !{!0, !1, !2, !3, !4}
+
+!0 = !{i32 2, !"SDK Version", [2 x i32] [i32 14, i32 4]}
+!1 = !{i32 1, !"wchar_size", i32 4}
+!2 = !{i32 8, !"PIC Level", i32 2}
+!3 = !{i32 7, !"uwtable", i32 1}
+!4 = !{i32 7, !"frame-pointer", i32 1}

--- a/llvm/test/CodeGen/SBF/warn-stack.ll
+++ b/llvm/test/CodeGen/SBF/warn-stack.ll
@@ -24,10 +24,10 @@ declare void @llvm.lifetime.end.p0i8(i64, i8* nocapture) #1
 ; CHECK: Error: warn_stack.c
 ; CHECK: please minimize large stack variables 
 define void @warn() local_unnamed_addr #0 !dbg !20 {
-  %1 = alloca [512 x i8], align 1
-  %2 = getelementptr inbounds [512 x i8], [512 x i8]* %1, i64 0, i64 0, !dbg !26
+  %1 = alloca [4124 x i8], align 1
+  %2 = getelementptr inbounds [4124 x i8], [4124 x i8]* %1, i64 0, i64 0, !dbg !26
   call void @llvm.lifetime.start.p0i8(i64 512, i8* nonnull %2) #4, !dbg !26
-  tail call void @llvm.dbg.declare(metadata [512 x i8]* %1, metadata !22, metadata !16), !dbg !27
+  tail call void @llvm.dbg.declare(metadata [4124 x i8]* %1, metadata !22, metadata !16), !dbg !27
   call void @doit(i8* nonnull %2) #4, !dbg !28
   call void @llvm.lifetime.end.p0i8(i64 512, i8* nonnull %2) #4, !dbg !29
   ret void, !dbg !29


### PR DESCRIPTION
**Problem**

When we compile a function that uses a lot of stack and that calls another function with stack arguments, we blindly overwrite values in the stack.


**Solution**

We will fail when that is the case and not emit a binary.