### PR TITLE
[SOL] Error out when a function access an invalid offset

### DIFF
--- a/llvm/lib/Target/SBF/SBFRegisterInfo.cpp
+++ b/llvm/lib/Target/SBF/SBFRegisterInfo.cpp
@@ -66,6 +66,8 @@ static void WarnSize(int Offset, MachineFunction &MF, DebugLoc& DL)
              << -MaxOffset << " by " << MaxOffset - Offset
              << " bytes, please minimize large stack variables. "
              << "Estimated function frame size: " << StackSize << " bytes.\n\n";
+      report_fatal_error("Exceeding the maximum stack offset may cause "
+                         "undefined behavior, including the loss of funds.");
     } else {
       DiagnosticInfoUnsupported DiagStackSize(
           MF.getFunction(),

--- a/llvm/test/CodeGen/SBF/warn-stack.ll
+++ b/llvm/test/CodeGen/SBF/warn-stack.ll
@@ -1,4 +1,4 @@
-; RUN: llc -march=sbf < %s 2>&1 >/dev/null | FileCheck %s
+; RUN: not --crash llc -march=sbf < %s 2>&1 >/dev/null | FileCheck %s
 
 define void @nowarn() local_unnamed_addr #0 !dbg !6 {
   %1 = alloca [4096 x i8], align 1
@@ -22,7 +22,8 @@ declare void @doit(i8*) local_unnamed_addr #3
 declare void @llvm.lifetime.end.p0i8(i64, i8* nocapture) #1
 
 ; CHECK: Error: warn_stack.c
-; CHECK: please minimize large stack variables 
+; CHECK: please minimize large stack variables
+; CHECK: Exceeding the maximum stack offset may cause undefined behavior, including the loss of funds.
 define void @warn() local_unnamed_addr #0 !dbg !20 {
   %1 = alloca [512 x i8], align 1
   %2 = getelementptr inbounds [512 x i8], [512 x i8]* %1, i64 0, i64 0, !dbg !26


### PR DESCRIPTION
**Problem**

We still emit code when a function access a stack offset outside its frame, even though this may cause runtime errors, data corruption and in an extreme scenario loss of funds.

**Solution**

Error out when this happens, halt compilation and not emit a binary.