### PR TITLE
[SOL] Do not crash for stack errors

### DIFF
--- a/llvm/lib/Target/SBF/SBFRegisterInfo.cpp
+++ b/llvm/lib/Target/SBF/SBFRegisterInfo.cpp
@@ -65,9 +65,9 @@ static void WarnSize(int Offset, MachineFunction &MF, DebugLoc& DL)
              << " Stack offset of " << -Offset << " exceeded max offset of "
              << -MaxOffset << " by " << MaxOffset - Offset
              << " bytes, please minimize large stack variables. "
-             << "Estimated function frame size: " << StackSize << " bytes.\n\n";
-      report_fatal_error("Exceeding the maximum stack offset may cause "
-                         "undefined behavior, including the loss of funds.");
+             << "Estimated function frame size: " << StackSize << " bytes."
+             << " Exceeding the maximum stack offset may cause "
+                "unexpected behavior during execution.\n\n";
     } else {
       DiagnosticInfoUnsupported DiagStackSize(
           MF.getFunction(),
@@ -166,9 +166,9 @@ int SBFRegisterInfo::resolveInternalFrameIndex(
       dbgs() << "Error: A function call in method "
              << MF.getFunction().getName()
              << " overwrites values in the frame. Please, decrease stack usage "
-             << "or remove parameters from the call.\n\n";
-      report_fatal_error(
-          "The function call may cause undefined behavior during execution.");
+             << "or remove parameters from the call."
+             << "The function call may cause undefined behavior "
+                "during execution.\n\n";
     }
     Offset = -Offset;
   } else if (MF.getSubtarget<SBFSubtarget>().getEnableNewCallConvention() &&

--- a/llvm/lib/Target/SBF/SBFRegisterInfo.cpp
+++ b/llvm/lib/Target/SBF/SBFRegisterInfo.cpp
@@ -67,7 +67,7 @@ static void WarnSize(int Offset, MachineFunction &MF, DebugLoc& DL)
              << " bytes, please minimize large stack variables. "
              << "Estimated function frame size: " << StackSize << " bytes."
              << " Exceeding the maximum stack offset may cause "
-                "unexpected behavior during execution.\n\n";
+                "undefined behavior during execution.\n\n";
     } else {
       DiagnosticInfoUnsupported DiagStackSize(
           MF.getFunction(),

--- a/llvm/test/CodeGen/SBF/func_call_error.ll
+++ b/llvm/test/CodeGen/SBF/func_call_error.ll
@@ -1,4 +1,4 @@
-; RUN: not --crash llc < %s -march=sbf 2>&1 | FileCheck %s
+; RUN: llc < %s -march=sbf 2>&1 | FileCheck %s
 
 ; Function Attrs: noinline nounwind optnone ssp uwtable(sync)
 define i32 @func(i32 noundef %0, i32 noundef %1, i32 noundef %2, i32 noundef %3, i32 noundef %4, i32 noundef %5) #0 {

--- a/llvm/test/CodeGen/SBF/warn-stack.ll
+++ b/llvm/test/CodeGen/SBF/warn-stack.ll
@@ -1,4 +1,4 @@
-; RUN: not --crash llc -march=sbf < %s 2>&1 >/dev/null | FileCheck %s
+; RUN: llc -march=sbf < %s 2>&1 >/dev/null | FileCheck %s
 
 define void @nowarn() local_unnamed_addr #0 !dbg !6 {
   %1 = alloca [4096 x i8], align 1
@@ -23,7 +23,7 @@ declare void @llvm.lifetime.end.p0i8(i64, i8* nocapture) #1
 
 ; CHECK: Error: warn_stack.c
 ; CHECK: please minimize large stack variables
-; CHECK: Exceeding the maximum stack offset may cause undefined behavior, including the loss of funds.
+; CHECK: Exceeding the maximum stack offset may cause unexpected behavior during execution.
 define void @warn() local_unnamed_addr #0 !dbg !20 {
   %1 = alloca [4124 x i8], align 1
   %2 = getelementptr inbounds [4124 x i8], [4124 x i8]* %1, i64 0, i64 0, !dbg !26

--- a/llvm/test/CodeGen/SBF/warn-stack.ll
+++ b/llvm/test/CodeGen/SBF/warn-stack.ll
@@ -23,7 +23,7 @@ declare void @llvm.lifetime.end.p0i8(i64, i8* nocapture) #1
 
 ; CHECK: Error: warn_stack.c
 ; CHECK: please minimize large stack variables
-; CHECK: Exceeding the maximum stack offset may cause unexpected behavior during execution.
+; CHECK: Exceeding the maximum stack offset may cause undefined behavior during execution.
 define void @warn() local_unnamed_addr #0 !dbg !20 {
   %1 = alloca [4124 x i8], align 1
   %2 = getelementptr inbounds [4124 x i8], [4124 x i8]* %1, i64 0, i64 0, !dbg !26


### PR DESCRIPTION
**Problem**

Halting the compiler for stack errors is not a good experience, because we'll be stoping compilation for cases when a function isn't even linked in the final file. Lastly, creating a reliable way to emit errors in LLD involves many changes that may not be worth the time, given that we may soon enable dynamic stack frames.


**Solution**

Remove the `report_fatal_error` functions and do another compiler release before Rust 1.79.