### PR TITLE
Allow LLD to process bitcode for SBF

### DIFF
--- a/.github/workflows/lld-tests.yml
+++ b/.github/workflows/lld-tests.yml
@@ -15,9 +15,9 @@ on:
       - '.github/workflows/llvm-project-tests.yml'
       - '!llvm/**'
   pull_request:
-    ignore-forks: true
-    branches:
-      - 'release/**'
+    # ignore-forks: true
+    # branches:
+    #   - 'release/**'
     paths:
       - 'lld/**'
       - '.github/workflows/lld-tests.yml'
@@ -32,7 +32,7 @@ concurrency:
 
 jobs:
   check_lld:
-    if: github.repository_owner == 'llvm'
+    # if: github.repository_owner == 'llvm'
     name: Test lld
     uses: ./.github/workflows/llvm-project-tests.yml
     with:

--- a/lld/ELF/InputFiles.cpp
+++ b/lld/ELF/InputFiles.cpp
@@ -1620,6 +1620,8 @@ static uint16_t getBitcodeMachineKind(StringRef path, const Triple &t) {
     return t.isOSIAMCU() ? EM_IAMCU : EM_386;
   case Triple::x86_64:
     return EM_X86_64;
+  case Triple::sbf:
+    return EM_SBF;
   default:
     error(path + ": could not infer e_machine from bitcode target triple " +
           t.str());


### PR DESCRIPTION
The change is simply an addition in function `getBitcodeMachineKind`. This is necessary to enable LTO.