### PR TITLE
[SOL] Revamp peephole pass for explicit sign extension

### DIFF
--- a/llvm/lib/Target/SBF/SBFTargetMachine.cpp
+++ b/llvm/lib/Target/SBF/SBFTargetMachine.cpp
@@ -158,12 +158,10 @@ void SBFPassConfig::addMachineSSAOptimization() {
   // Peephole ran at last.
   TargetPassConfig::addMachineSSAOptimization();
 
-//  const SBFSubtarget *Subtarget = getSBFTargetMachine().getSubtargetImpl();
+  const SBFSubtarget *Subtarget = getSBFTargetMachine().getSubtargetImpl();
   if (!DisableMIPeephole) {
-// TODO: The peephole doesn't work with explicit sign extension. A future PR
-// will revamp the implementation.
-//    if (Subtarget->getHasAlu32())
-//      addPass(createSBFMIPeepholePass());
+    if (Subtarget->getHasAlu32() && Subtarget->getHasExplicitSignExt())
+      addPass(createSBFMIPeepholePass());
     addPass(createSBFMIPeepholeTruncElimPass());
   }
 }

--- a/llvm/test/CodeGen/SBF/32-bit-subreg-cond-select.ll
+++ b/llvm/test/CodeGen/SBF/32-bit-subreg-cond-select.ll
@@ -56,8 +56,8 @@ entry:
   ret i32 %c.d
 }
 ; CHECK-LABEL: select_cc_32
-; CHECK: mov64 r{{[0-9]+}}, w{{[0-9]+}}
-; CHECK: mov64 r{{[0-9]+}}, w{{[0-9]+}}
+; CHECK-NOT: mov64 r{{[0-9]+}}, w{{[0-9]+}}
+; CHECK-NOT: mov64 r{{[0-9]+}}, w{{[0-9]+}}
 ; CHECK: jgt r{{[0-9]+}}, r{{[0-9]+}}
 ; CHECK-NOT: lsh64 r{{[0-9]+}}, 32
 ; CHECK-NOT: rsh64 r{{[0-9]+}}, 32

--- a/llvm/test/CodeGen/SBF/atomics_sbf.ll
+++ b/llvm/test/CodeGen/SBF/atomics_sbf.ll
@@ -67,9 +67,9 @@ entry:
 
 ; CHECK-LABEL: test_cas_32
 ; CHECK: ldxw w0, [r1 + 0]
-; CHECK: mov64 r4, w0
-; CHECK: mov64 r2, w2
-; CHECK: jeq r4, r2,
+; CHECK-NOT: mov64 r4, w0
+; CHECK-NOT: mov64 r2, w2
+; CHECK: jeq r0, r2,
 ; CHECK: mov64 w3, w0
 ; CHECK: stxw [r1 + 0], w3
 define dso_local i32 @test_cas_32(i32* nocapture %p, i32 %old, i32 %new) local_unnamed_addr {
@@ -235,10 +235,10 @@ entry:
 
 ; CHECK-LABEL: test_umin_32
 ; CHECK: ldxw w0, [r1 + 0]
-; CHECK: mov64 r4, w2
-; CHECK: mov64 r5, w0
+; CHECK-NOT: mov64 r4, w2
+; CHECK-NOT: mov64 r5, w0
 ; CHECK: mov64 w3, w0
-; CHECK: jgt r4, r5,
+; CHECK: jgt r2, r0,
 ; CHECK: mov64 w3, w2
 ; CHECK: stxw [r1 + 0], w3
 define dso_local  i32 @test_umin_32(i32* nocapture %ptr, i32 %v) local_unnamed_addr #0 {
@@ -261,10 +261,10 @@ entry:
 
 ; CHECK-LABEL: test_umax_32
 ; CHECK: ldxw w0, [r1 + 0]
-; CHECK: mov64 r4, w0
-; CHECK: mov64 r5, w2
+; CHECK-NOT: mov64 r4, w0
+; CHECK-NOT: mov64 r4, w2
 ; CHECK: mov64 w3, w0
-; CHECK: jgt r4, r5
+; CHECK: jgt r0, r2
 ; CHECK: mov64 w3, w2
 ; CHECK: stxw [r1 + 0], w3
 define dso_local  i32 @test_umax_32(i32* nocapture %ptr, i32 %v) local_unnamed_addr #0 {
@@ -330,9 +330,9 @@ entry:
 
 ; CHECK-LABEL: test_weak_cas_32
 ; CHECK: ldxw w4, [r1 + 0]
-; CHECK: mov64 r5, w4
-; CHECK: mov64 r2, w2
-; CHECK: jeq r5, r2,
+; CHECK-NOT: mov64 r5, w4
+; CHECK-NOT: mov64 r2, w2
+; CHECK: jeq r4, r2,
 ; CHECK: stxw [r1 + 0], w3
 define dso_local void @test_weak_cas_32(i32* nocapture %p, i32 %old, i32 %new) local_unnamed_addr {
 entry:

--- a/llvm/test/CodeGen/SBF/peephole-explict-sext.ll
+++ b/llvm/test/CodeGen/SBF/peephole-explict-sext.ll
@@ -1,0 +1,12 @@
+; RUN: llc < %s -march=sbf -mattr=+alu32,+explicit-sext | FileCheck %s
+
+define dso_local i32 @select_cc_32(i32 %a, i32 %b, i32 %c, i32 %d) local_unnamed_addr #0 {
+entry:
+; CHECK-LABEL: select_cc_32
+  %cmp = icmp ugt i32 %a, %b
+; CHECK-NOT: mov64 r{{[0-9]+}}, w1
+; CHECK-NOT: mov64 r{{[0-9]+}}, w2
+; CHECK: jgt r1, r2,
+  %c.d = select i1 %cmp, i32 %c, i32 %d
+  ret i32 %c.d
+}


### PR DESCRIPTION
PR #116 commented out the peephole pass that used to remove unnecessary sign extensions when the ALU32 target feature was enabled. This PR revamps the implementation to remove redundant MOV64 that serves as zero extension.

The reason this works is the following:

1. Every ALU32 instructions, except for `mov32 reg, reg`, zero extends values. This also includes `mov32 reg, imm`
2. Truncating from a 64-bit register will always require a bit mask.
3. We don't emit `mov32 reg, reg` for copying 32-bit values.
4. It is safe to assume that every value in a 32-bit register is always zero extended, so the MOV64 is unnecessary (it only acts as a copy).