### PR TITLE
[SOL] Simplify code emission for syscalls

### DIFF
--- a/llvm/lib/Target/SBF/SBFISelLowering.cpp
+++ b/llvm/lib/Target/SBF/SBFISelLowering.cpp
@@ -592,16 +592,11 @@ SDValue SBFTargetLowering::LowerCall(TargetLowering::CallLoweringInfo &CLI,
   // If the callee is a GlobalAddress node (quite common, every direct call is)
   // turn it into a TargetGlobalAddress node so that legalize doesn't hack it.
   // Likewise ExternalSymbol -> TargetExternalSymbol.
-  unsigned NodeCode = SBFISD::CALL;
   if (GlobalAddressSDNode *G = dyn_cast<GlobalAddressSDNode>(Callee)) {
     Callee = DAG.getTargetGlobalAddress(G->getGlobal(), CLI.DL, PtrVT,
                                         G->getOffset(), 0);
   } else if (ExternalSymbolSDNode *E = dyn_cast<ExternalSymbolSDNode>(Callee)) {
     Callee = DAG.getTargetExternalSymbol(E->getSymbol(), PtrVT, 0);
-  } else if (isa<ConstantSDNode>(Callee) && Subtarget->getHasStaticSyscalls()) {
-    // When static syscalls are enabled and we have a constant operand for call,
-    // we emit a syscall.
-    NodeCode = SBFISD::SYSCALL;
   }
 
   // Returns a chain & a flag for retval copy to use.
@@ -622,7 +617,7 @@ SDValue SBFTargetLowering::LowerCall(TargetLowering::CallLoweringInfo &CLI,
   if (InGlue.getNode())
     Ops.push_back(InGlue);
 
-  Chain = DAG.getNode(NodeCode, CLI.DL, NodeTys, Ops);
+  Chain = DAG.getNode(SBFISD::CALL, CLI.DL, NodeTys, Ops);
   InGlue = Chain.getValue(1);
 
   DAG.addNoMergeSiteInfo(Chain.getNode(), CLI.NoMerge);
@@ -924,8 +919,6 @@ const char *SBFTargetLowering::getTargetNodeName(unsigned Opcode) const {
     return "SBFISD::Wrapper";
   case SBFISD::MEMCPY:
     return "SBFISD::MEMCPY";
-  case SBFISD::SYSCALL:
-    return "SBFISD::SYSCALL";
   }
   return nullptr;
 }

--- a/llvm/lib/Target/SBF/SBFISelLowering.h
+++ b/llvm/lib/Target/SBF/SBFISelLowering.h
@@ -29,7 +29,6 @@ enum NodeType : unsigned {
   BR_CC,
   Wrapper,
   MEMCPY,
-  SYSCALL,
 };
 }
 

--- a/llvm/lib/Target/SBF/SBFInstrInfo.td
+++ b/llvm/lib/Target/SBF/SBFInstrInfo.td
@@ -32,13 +32,10 @@ def SDT_SBFMEMCPY       : SDTypeProfile<0, 4, [SDTCisVT<0, i64>,
                                                SDTCisVT<1, i64>,
                                                SDTCisVT<2, i64>,
                                                SDTCisVT<3, i64>]>;
-def SDT_SBFSyscall      : SDTypeProfile<0, 1, [SDTCisVT<0, i64>]>;
 
 def SBFcall         : SDNode<"SBFISD::CALL", SDT_SBFCall,
                              [SDNPHasChain, SDNPOptInGlue, SDNPOutGlue,
                               SDNPVariadic]>;
-def SBFSyscall     : SDNode<"SBFISD::SYSCALL", SDT_SBFSyscall,
-                            [SDNPHasChain, SDNPOptInGlue, SDNPOutGlue]>;
 def SBFretglue     : SDNode<"SBFISD::RET_GLUE", SDTNone,
                              [SDNPHasChain, SDNPOptInGlue, SDNPVariadic]>;
 def SBFcallseq_start: SDNode<"ISD::CALLSEQ_START", SDT_SBFCallSeqStart,
@@ -966,7 +963,7 @@ def : Pat<(SBFcall texternalsym:$dst), (JAL texternalsym:$dst)>;
 def : Pat<(SBFcall imm:$dst), (JAL imm:$dst)>, Requires<[SBFNoStaticSyscalls]>;
 def : Pat<(SBFcall GPR:$dst), (JALX GPR:$dst)>, Requires<[SBFNoCallxSrc]>;
 def : Pat<(SBFcall GPR:$dst), (JALX_v2 GPR:$dst)>, Requires<[SBFCallxSrc]>;
-def : Pat<(SBFSyscall imm:$imm), (SYSCALL_v3 imm:$imm)>, Requires<[SBFHasStaticSyscalls]>;
+def : Pat<(SBFcall imm:$imm), (SYSCALL_v3 imm:$imm)>, Requires<[SBFHasStaticSyscalls]>;
 
 // Loads
 let Predicates = [SBFNoALU32, SBFOldMemEncoding] in {

--- a/llvm/test/CodeGen/SBF/static_syscall.ll
+++ b/llvm/test/CodeGen/SBF/static_syscall.ll
@@ -1,5 +1,5 @@
-; RUN: llc -march=sbf < %s | FileCheck --check-prefix=CHECK-V0 %s
-; RUN: llc -march=sbf -mattr=+static-syscalls -show-mc-encoding < %s | FileCheck --check-prefix=CHECK-V3 %s
+; RUN: llc -march=sbf < %s | FileCheck --check-prefixes=CHECK,CHECK-V0 %s
+; RUN: llc -march=sbf -mattr=+static-syscalls -show-mc-encoding < %s | FileCheck --check-prefixes=CHECK,CHECK-V3 %s
 
 
 ; Function Attrs: nounwind
@@ -19,7 +19,14 @@ entry:
 ; CHECK-V3: syscall 112
   %syscall_3 = tail call i32 inttoptr (i64 112 to ptr)(i32 noundef %a, i32 noundef %b)
 
+; CHECK: mov64 r1, 89
+; CHECK: mov64 r2, 87
+; CHECK-V0: call 112
+; CHECK-V3: syscall 112
+  %syscall_4 = tail call i32 inttoptr (i64 112 to ptr)(i32 89,  i32 87)
+
   %add_1 = add i32 %syscall_1, %syscall_2
   %add_2 = add i32 %add_1, %syscall_3
-  ret i32 %add_1
+  %add_3 = add i32 %add_2, %syscall_4
+  ret i32 %add_3
 }


### PR DESCRIPTION
While running integration tests for static syscalls and the stricter verifier, I found out I wasn't properly saving arguments to registers when emitting a sys call instruction.

This PR simplifies the code generation for syscalls and fixes the issue.