### PR TITLE
[SOL] Remove +solana flag from clang

### DIFF
--- a/clang/lib/Driver/ToolChains/Arch/BPF.cpp
+++ b/clang/lib/Driver/ToolChains/Arch/BPF.cpp
@@ -47,13 +47,6 @@ void bpf::getBPFTargetFeatures(const Driver &D, const ArgList &Args,
   Arg *A;
   bool success = true;
 
-  if ((A = Args.getLastArg(options::OPT_target))) {
-    StringRef Target = A->getValue();
-    if (Target == "sbf") {
-      Features.push_back("+solana");
-    }
-  }
-
   if ((A = Args.getLastArg(options::OPT_march_EQ)))
     success = getBPFArchFeaturesFromMarch(D, A->getValue(), Args, Features);
   if (!success)


### PR DESCRIPTION
Since #113 we do not support the `+solana` flag anymore, so we can remove it from clang.