### PR TITLE
[SOL] Add return instructions for functions that end with unreachable

### DIFF
--- a/llvm/test/CodeGen/SBF/unreachable_return.ll
+++ b/llvm/test/CodeGen/SBF/unreachable_return.ll
@@ -1,0 +1,17 @@
+; RUN: llc -O2 -march=sbf -mcpu=v3 < %s | FileCheck %s
+
+declare void @dummy_func(i8, ptr, ptr, ptr, ptr, ptr, ptr)
+
+define internal fastcc void @test_func(ptr %0, ptr %1, ptr %args, ptr %2) {
+start:
+; CHECK: add64 r10, -64
+  %right = alloca [8 x i8], align 8
+  %left = alloca [8 x i8], align 8
+  store ptr %0, ptr %left, align 8
+  store ptr %1, ptr %right, align 8
+  call void @dummy_func(i8 0, ptr %left, ptr %left, ptr %right, ptr %right, ptr %args, ptr %2)
+  unreachable
+; CHECK: call dummy_func
+; CHECK-NOT: add64 r10, 64
+; CHECK: return
+}


### PR DESCRIPTION
In SBFv3, functions must end with either a JA or a return instructions. When that doesn't happen, program verification will fail.

LLVM does not emit returns or epilogues when a function terminates with a call that never returns, specifically, when the callee halts execution. This PR introduces a pre-emit phase peephole pass that adds a return to a basic block that ends with a call instruction and has no successors. Please, refer to the comment in the code for why I took this approach.