### PR TITLE
[SOL] Define page and base sizes for SBF

### DIFF
--- a/lld/ELF/Arch/SBF.cpp
+++ b/lld/ELF/Arch/SBF.cpp
@@ -38,6 +38,9 @@ public:
 SBF::SBF() {
   relativeRel = R_SBF_64_RELATIVE;
   symbolicRel = R_SBF_64_64;
+  defaultCommonPageSize = 8;
+  defaultMaxPageSize = 8;
+  defaultImageBase = 0;
 }
 
 RelExpr SBF::getRelExpr(RelType type, const Symbol &s,
@@ -78,7 +81,6 @@ int64_t SBF::getImplicitAddend(const uint8_t *buf, RelType type) const {
   default:
     return 0;
   }
-  return 0;
 }
 
 void SBF::relocate(uint8_t *loc, const Relocation &rel, uint64_t val) const {


### PR DESCRIPTION
Defining 8 for `defaultCommonPageSize` and `defaultMaxPageSize`, and zero for `defaultImageBase` removes padding from the final binary and decreases program size.