### PR TITLE
[SOL] Correctly disassemble store imm

### DIFF
--- a/llvm/test/CodeGen/SBF/store-imm.ll
+++ b/llvm/test/CodeGen/SBF/store-imm.ll
@@ -1,6 +1,7 @@
 ; RUN: llc < %s -march=sbf -mattr=+store-imm -show-mc-encoding | FileCheck %s
 ; RUN: llc < %s -march=sbf -mattr=+store-imm,+alu32 -show-mc-encoding | FileCheck %s
 ; RUN: llc < %s -march=sbf -mattr=+store-imm,+mem-encoding -show-mc-encoding | FileCheck --check-prefix=CHECK-V2 %s
+; RUN: llc -march=sbf -mcpu=v3 -filetype=obj -o - %s | llvm-objdump -d --no-print-imm-hex - | FileCheck --check-prefix=CHECK-DUMP %s
 
 define void @byte(ptr %p0) {
 ; CHECK-LABEL: byte:
@@ -10,6 +11,10 @@ define void @byte(ptr %p0) {
 
 ; CHECK-V2:    stb [r1 + 0], 1       # encoding: [0x27,0x01,0x00,0x00,0x01,0x00,0x00,0x00]
 ; CHECK-V2:    stb [r1 + 1], 255     # encoding: [0x27,0x01,0x01,0x00,0xff,0x00,0x00,0x00]
+
+; CHECK-DUMP: stb [r1 + 0], 1
+; CHECK-DUMP: stb [r1 + 1], 255
+
   %p1 = getelementptr i8, ptr %p0, i32 1
   store volatile i8  1, ptr %p0, align 1
   store volatile i8 -1, ptr %p1, align 1
@@ -23,6 +28,10 @@ define void @half(ptr, ptr %p0) {
 
 ; CHECK-V2:    sth [r2 + 0], 1          # encoding: [0x37,0x02,0x00,0x00,0x01,0x00,0x00,0x00]
 ; CHECK-V2:    sth [r2 + 2], 65535      # encoding: [0x37,0x02,0x02,0x00,0xff,0xff,0x00,0x00]
+
+; CHECK-DUMP:    sth [r2 + 0], 1
+; CHECK-DUMP:    sth [r2 + 2], 65535
+
   %p1 = getelementptr i8, ptr %p0, i32 2
   store volatile i16  1, ptr %p0, align 2
   store volatile i16 -1, ptr %p1, align 2
@@ -42,6 +51,13 @@ define void @word(ptr, ptr, ptr %p0) {
 ; CHECK-V2:    stw [r3 + 8], -2000000000  # encoding: [0x87,0x03,0x08,0x00,0x00,0x6c,0xca,0x88]
 ; CHECK-V2:    stw [r3 + 12], -1          # encoding: [0x87,0x03,0x0c,0x00,0xff,0xff,0xff,0xff]
 ; CHECK-V2:    stw [r3 + 12], 0           # encoding: [0x87,0x03,0x0c,0x00,0x00,0x00,0x00,0x00]
+
+; CHECK-DUMP:    stw [r3 + 0], 1
+; CHECK-DUMP:    stw [r3 + 4], -1
+; CHECK-DUMP:    stw [r3 + 8], -2000000000
+; CHECK-DUMP:    stw [r3 + 12], -1
+; CHECK-DUMP:    stw [r3 + 12], 0
+
   %p1 = getelementptr i8, ptr %p0, i32 4
   %p2 = getelementptr i8, ptr %p0, i32 8
   %p3 = getelementptr i8, ptr %p0, i32 12
@@ -68,6 +84,12 @@ define void @dword(ptr, ptr, ptr, ptr %p0) {
 ; CHECK-V2:    stdw [r4 + 16], -2000000000  # encoding: [0x97,0x04,0x10,0x00,0x00,0x6c,0xca,0x88]
 ; CHECK-V2:    lddw r1, 4294967295          # encoding: [0x18,0x01,0x00,0x00,0xff,0xff,0xff,0xff,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00]
 ; CHECK-V2:    stxdw [r4 + 24], r1          # encoding: [0x9f,0x14,0x18,0x00,0x00,0x00,0x00,0x00]
+
+; CHECK-DUMP:    stdw [r4 + 0], 1
+; CHECK-DUMP:    stdw [r4 + 8], -1
+; CHECK-DUMP:    stdw [r4 + 16], 2000000000
+; CHECK-DUMP:    stdw [r4 + 16], -2000000000
+
   %p1 = getelementptr i8, ptr %p0, i32 8
   %p2 = getelementptr i8, ptr %p0, i32 16
   %p3 = getelementptr i8, ptr %p0, i32 24


### PR DESCRIPTION
There was a bug in the disassembler code for store imm. I found it while analyzing some programs with `llvm-objdump`.

The fix was simply matching the instruction Opcode to the correct decoding table.