### PR TITLE
[SOL] Fine tune memory operations threshold

### DIFF
--- a/llvm/test/CodeGen/SBF/i128.ll
+++ b/llvm/test/CodeGen/SBF/i128.ll
@@ -32,10 +32,9 @@ entry:
 }
 
 ; CHECK-LABEL: test
-; CHECK:       mov64 r7, r10
-; CHECK:       add64 r7, -32 
-; CHECK:       mov64 r1, r7
 ; CHECK:       stxw [r10 - 32], r{{[0-9]+}}
+; CHECK:       mov64 r1, r10
+; CHECK:       add64 r1, -32
 
 ; Function Attrs: argmemonly nounwind willreturn
 declare void @llvm.lifetime.start.p0i8(i64 immarg, i8* nocapture) #1


### PR DESCRIPTION
The threshold for invoking the library functions was not properly tuned for CU consumption. I changed the thresholds so that we call the library if the expansion emits more than ten instructions.

I'm assuming this change will be used together with https://github.com/anza-xyz/compiler-builtins/pull/31.

Thanks to @febo for bringing this up.