### PR TITLE
[SOL] Create SBF sub architectures

### DIFF
--- a/llvm/include/llvm/TargetParser/Triple.h
+++ b/llvm/include/llvm/TargetParser/Triple.h
@@ -166,6 +166,10 @@ public:
     SPIRVSubArch_v14,
     SPIRVSubArch_v15,
     SPIRVSubArch_v16,
+
+    SBFSubArch_v1,
+    SBFSubArch_v2,
+    SBFSubArch_v3,
   };
   enum VendorType {
     UnknownVendor,

--- a/llvm/lib/Target/SBF/MCTargetDesc/SBFMCTargetDesc.cpp
+++ b/llvm/lib/Target/SBF/MCTargetDesc/SBFMCTargetDesc.cpp
@@ -54,7 +54,9 @@ static MCRegisterInfo *createSBFMCRegisterInfo(const Triple &TT) {
 
 static MCSubtargetInfo *createSBFMCSubtargetInfo(const Triple &TT,
                                                  StringRef CPU, StringRef FS) {
-  return createSBFMCSubtargetInfoImpl(TT, CPU, /*TuneCPU*/ CPU, FS);
+  std::string CpuStr = cpuFromSubArch(TT, CPU.str());
+  StringRef CpuRef = CpuStr;
+  return createSBFMCSubtargetInfoImpl(TT, CpuRef, /*TuneCPU*/ CpuRef, FS);
 }
 
 static MCStreamer *createSBFMCStreamer(const Triple &T, MCContext &Ctx,

--- a/llvm/lib/Target/SBF/SBFSubtarget.cpp
+++ b/llvm/lib/Target/SBF/SBFSubtarget.cpp
@@ -14,6 +14,7 @@
 #include "SBF.h"
 #include "llvm/MC/TargetRegistry.h"
 #include "llvm/TargetParser/Host.h"
+#include "TargetInfo/SBFTargetInfo.h"
 
 using namespace llvm;
 
@@ -59,8 +60,8 @@ void SBFSubtarget::initSubtargetFeatures(StringRef CPU, StringRef FS) {
 
 SBFSubtarget::SBFSubtarget(const Triple &TT, const std::string &CPU,
                            const std::string &FS, const TargetMachine &TM)
-    : SBFGenSubtargetInfo(TT, CPU, /*TuneCPU*/ CPU, FS), InstrInfo(),
-      FrameLowering(initializeSubtargetDependencies(TT, CPU, FS)),
+    : SBFGenSubtargetInfo(TT, cpuFromSubArch(TT, CPU), /*TuneCPU*/ cpuFromSubArch(TT, CPU), FS), InstrInfo(),
+      FrameLowering(initializeSubtargetDependencies(TT, cpuFromSubArch(TT, CPU), FS)),
       TLInfo(TM, *this) {
   assert(TT.getArch() == Triple::sbf && "expected Triple::sbf");
 }

--- a/llvm/lib/Target/SBF/TargetInfo/SBFTargetInfo.cpp
+++ b/llvm/lib/Target/SBF/TargetInfo/SBFTargetInfo.cpp
@@ -16,6 +16,32 @@ Target &llvm::getTheSBFXTarget() {
   return TheSBFTarget;
 }
 
+std::string llvm::cpuFromSubArch(const Triple &TT, const std::string &CPU) {
+  std::string CpuType;
+  switch (TT.getSubArch()) {
+  case Triple::SBFSubArch_v1:
+    CpuType = "v1";
+    break;
+  case Triple::SBFSubArch_v2:
+    CpuType = "v2";
+    break;
+  case Triple::SBFSubArch_v3:
+    CpuType = "v3";
+    break;
+  default:
+    break;
+  }
+
+  assert((CPU.empty() || CpuType.empty() || CPU == CpuType) &&
+         "Subarch type must match CPU type");
+
+  if (!CpuType.empty()) {
+    return CpuType;
+  }
+
+  return CPU;
+}
+
 extern "C" LLVM_EXTERNAL_VISIBILITY void LLVMInitializeSBFTargetInfo() {
   TargetRegistry::RegisterTarget(
       getTheSBFXTarget(), "sbf", "SBF new (little endian)", "SBF",

--- a/llvm/lib/Target/SBF/TargetInfo/SBFTargetInfo.h
+++ b/llvm/lib/Target/SBF/TargetInfo/SBFTargetInfo.h
@@ -5,6 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
+#include "llvm/TargetParser/Triple.h"
 
 #ifndef LLVM_LIB_TARGET_SBF_TARGETINFO_SBFTARGETINFO_H
 #define LLVM_LIB_TARGET_SBF_TARGETINFO_SBFTARGETINFO_H
@@ -14,6 +15,7 @@ namespace llvm {
 class Target;
 
 Target &getTheSBFXTarget();
+std::string cpuFromSubArch(const Triple &TT, const std::string &CPU);
 } // namespace llvm
 
 #endif // LLVM_LIB_TARGET_SBF_TARGETINFO_SBFTARGETINFO_H

--- a/llvm/lib/TargetParser/Triple.cpp
+++ b/llvm/lib/TargetParser/Triple.cpp
@@ -359,7 +359,8 @@ static Triple::ArchType parseBPFArch(StringRef ArchName) {
     return Triple::bpfeb;
   } else if (ArchName.equals("bpf_le") || ArchName.equals("bpfel")) {
     return Triple::bpfel;
-  } else if (ArchName.equals("sbf")) {
+  } else if (ArchName.equals("sbf") || ArchName.equals("sbfv1") ||
+             ArchName.equals("sbfv2") || ArchName.equals("sbfv3")) {
     return Triple::sbf;
   } else {
     return Triple::UnknownArch;
@@ -744,6 +745,14 @@ static Triple::SubArchType parseSubArch(StringRef SubArchName) {
         .EndsWith("v1.5", Triple::SPIRVSubArch_v15)
         .EndsWith("v1.6", Triple::SPIRVSubArch_v16)
         .Default(Triple::NoSubArch);
+
+  if (SubArchName.starts_with("sbf")) {
+    return StringSwitch<Triple::SubArchType>(SubArchName)
+        .EndsWith("v1", Triple::SBFSubArch_v1)
+        .EndsWith("v2", Triple::SBFSubArch_v2)
+        .EndsWith("v3", Triple::SBFSubArch_v3)
+        .Default(Triple::NoSubArch);
+  }
 
   StringRef ARMSubArch = ARM::getCanonicalArchName(SubArchName);
 

--- a/llvm/lib/TargetParser/Triple.cpp
+++ b/llvm/lib/TargetParser/Triple.cpp
@@ -359,8 +359,9 @@ static Triple::ArchType parseBPFArch(StringRef ArchName) {
     return Triple::bpfeb;
   } else if (ArchName.equals("bpf_le") || ArchName.equals("bpfel")) {
     return Triple::bpfel;
-  } else if (ArchName.equals("sbf") || ArchName.equals("sbfv1") ||
-             ArchName.equals("sbfv2") || ArchName.equals("sbfv3")) {
+  } else if (ArchName.equals("sbf") || ArchName.equals("sbpf") ||
+             ArchName.equals("sbpfv1") || ArchName.equals("sbpfv2") ||
+             ArchName.equals("sbpfv3")) {
     return Triple::sbf;
   } else {
     return Triple::UnknownArch;
@@ -398,6 +399,7 @@ Triple::ArchType Triple::getArchTypeForLLVMName(StringRef Name) {
     .Case("riscv64", riscv64)
     .Case("hexagon", hexagon)
     .Case("sbf", BPFArch)
+    .Case("sbpf", BPFArch)
     .Case("sparc", sparc)
     .Case("sparcel", sparcel)
     .Case("sparcv9", sparcv9)
@@ -588,7 +590,8 @@ static Triple::ArchType parseArch(StringRef ArchName) {
     if (ArchName.starts_with("arm") || ArchName.starts_with("thumb") ||
         ArchName.starts_with("aarch64"))
       return parseARMArch(ArchName);
-    if (ArchName.starts_with("bpf") || ArchName.starts_with("sbf"))
+    if (ArchName.starts_with("bpf") || ArchName.starts_with("sbf") ||
+        ArchName.starts_with("sbpf"))
       return parseBPFArch(ArchName);
   }
 
@@ -746,7 +749,7 @@ static Triple::SubArchType parseSubArch(StringRef SubArchName) {
         .EndsWith("v1.6", Triple::SPIRVSubArch_v16)
         .Default(Triple::NoSubArch);
 
-  if (SubArchName.starts_with("sbf")) {
+  if (SubArchName.starts_with("sbpf")) {
     return StringSwitch<Triple::SubArchType>(SubArchName)
         .EndsWith("v1", Triple::SBFSubArch_v1)
         .EndsWith("v2", Triple::SBFSubArch_v2)

--- a/llvm/test/CodeGen/SBF/many_args_new_conv.ll
+++ b/llvm/test/CodeGen/SBF/many_args_new_conv.ll
@@ -1,4 +1,5 @@
 ; RUN: llc -O2 -march=sbf -mcpu=v1 < %s | FileCheck %s
+; RUN: llc -O2 -mtriple=sbfv1-solana-solana < %s | FileCheck %s
 ; RUN: llc -O2 -march=sbf -mcpu=v1 -mattr=+mem-encoding < %s | FileCheck %s
 
 ; Function Attrs: nounwind uwtable

--- a/llvm/test/CodeGen/SBF/many_args_new_conv.ll
+++ b/llvm/test/CodeGen/SBF/many_args_new_conv.ll
@@ -1,5 +1,5 @@
 ; RUN: llc -O2 -march=sbf -mcpu=v1 < %s | FileCheck %s
-; RUN: llc -O2 -mtriple=sbfv1-solana-solana < %s | FileCheck %s
+; RUN: llc -O2 -mtriple=sbpfv1-solana-solana < %s | FileCheck %s
 ; RUN: llc -O2 -march=sbf -mcpu=v1 -mattr=+mem-encoding < %s | FileCheck %s
 
 ; Function Attrs: nounwind uwtable

--- a/llvm/test/CodeGen/SBF/many_args_value_size.ll
+++ b/llvm/test/CodeGen/SBF/many_args_value_size.ll
@@ -1,5 +1,5 @@
 ; RUN: llc -march=sbf -mcpu=v2 < %s | FileCheck %s
-; RUN: llc -mtriple=sbfv2-solana-solana < %s | FileCheck %s
+; RUN: llc -mtriple=sbpfv2-solana-solana < %s | FileCheck %s
 
 define i64 @test_func(i64 %a, i64 %b, i64 %c, i64 %d, i64 %e) {
 start:

--- a/llvm/test/CodeGen/SBF/many_args_value_size.ll
+++ b/llvm/test/CodeGen/SBF/many_args_value_size.ll
@@ -1,4 +1,5 @@
 ; RUN: llc -march=sbf -mcpu=v2 < %s | FileCheck %s
+; RUN: llc -mtriple=sbfv2-solana-solana < %s | FileCheck %s
 
 define i64 @test_func(i64 %a, i64 %b, i64 %c, i64 %d, i64 %e) {
 start:

--- a/llvm/test/CodeGen/SBF/reloc-abs64-sbf.ll
+++ b/llvm/test/CodeGen/SBF/reloc-abs64-sbf.ll
@@ -1,6 +1,6 @@
 ; RUN: llc -march=sbf -filetype=obj < %s | llvm-objdump -r - | tee -i /tmp/foo | FileCheck --check-prefix=CHECK-RELOC-BPF %s
 ; RUN: llc -march=sbf -mcpu=v3 -filetype=obj < %s | llvm-objdump -r - | tee -i /tmp/foo | FileCheck --check-prefix=CHECK-RELOC-SBFv3 %s
-; RUN: llc -mtriple=sbfv3-solana-solana -filetype=obj < %s | llvm-objdump -r - | tee -i /tmp/foo | FileCheck --check-prefix=CHECK-RELOC-SBFv3 %s
+; RUN: llc -mtriple=sbpfv3-solana-solana -filetype=obj < %s | llvm-objdump -r - | tee -i /tmp/foo | FileCheck --check-prefix=CHECK-RELOC-SBFv3 %s
 
 @.str = private unnamed_addr constant [25 x i8] c"reloc_64_relative_data.c\00", align 1
 @FILE = dso_local constant i64 ptrtoint ([25 x i8]* @.str to i64), align 8

--- a/llvm/test/CodeGen/SBF/reloc-abs64-sbf.ll
+++ b/llvm/test/CodeGen/SBF/reloc-abs64-sbf.ll
@@ -1,5 +1,6 @@
 ; RUN: llc -march=sbf -filetype=obj < %s | llvm-objdump -r - | tee -i /tmp/foo | FileCheck --check-prefix=CHECK-RELOC-BPF %s
 ; RUN: llc -march=sbf -mcpu=v3 -filetype=obj < %s | llvm-objdump -r - | tee -i /tmp/foo | FileCheck --check-prefix=CHECK-RELOC-SBFv3 %s
+; RUN: llc -mtriple=sbfv3-solana-solana -filetype=obj < %s | llvm-objdump -r - | tee -i /tmp/foo | FileCheck --check-prefix=CHECK-RELOC-SBFv3 %s
 
 @.str = private unnamed_addr constant [25 x i8] c"reloc_64_relative_data.c\00", align 1
 @FILE = dso_local constant i64 ptrtoint ([25 x i8]* @.str to i64), align 8

--- a/llvm/test/MC/SBF/elf-flags.s
+++ b/llvm/test/MC/SBF/elf-flags.s
@@ -4,10 +4,19 @@
 # RUN: llvm-mc -triple=sbf-solana-solana -mcpu=v1 -filetype=obj < %s \
 # RUN:   | llvm-readobj --file-headers - \
 # RUN:   | FileCheck -check-prefix=CHECK-SBFV1 %s
-# RUN: llvm-mc -triple=sbf-solana-solana -mcpu=v1 -filetype=obj < %s \
+# RUN: llvm-mc -triple=sbfv1-solana-solana -filetype=obj < %s \
 # RUN:   | llvm-readobj --file-headers - \
 # RUN:   | FileCheck -check-prefix=CHECK-SBFV1 %s
+# RUN: llvm-mc -triple=sbf-solana-solana -mcpu=v2 -filetype=obj < %s \
+# RUN:   | llvm-readobj --file-headers - \
+# RUN:   | FileCheck -check-prefix=CHECK-SBFV2 %s
+# RUN: llvm-mc -triple=sbfv2-solana-solana -filetype=obj < %s \
+# RUN:   | llvm-readobj --file-headers - \
+# RUN:   | FileCheck -check-prefix=CHECK-SBFV2 %s
 # RUN: llvm-mc -triple=sbf-solana-solana -mcpu=v3 -filetype=obj < %s \
+# RUN:   | llvm-readobj --file-headers - \
+# RUN:   | FileCheck -check-prefix=CHECK-SBFV3 %s
+# RUN: llvm-mc -triple=sbfv3-solana-solana -filetype=obj < %s \
 # RUN:   | llvm-readobj --file-headers - \
 # RUN:   | FileCheck -check-prefix=CHECK-SBFV3 %s
 

--- a/llvm/test/MC/SBF/elf-flags.s
+++ b/llvm/test/MC/SBF/elf-flags.s
@@ -1,22 +1,25 @@
 # RUN: llvm-mc -triple=sbf-solana-solana -filetype=obj < %s \
 # RUN:   | llvm-readobj --file-headers - \
 # RUN:   | FileCheck -check-prefix=CHECK-NONE %s
+# RUN: llvm-mc -triple=sbpf-solana-solana -filetype=obj < %s \
+# RUN:   | llvm-readobj --file-headers - \
+# RUN:   | FileCheck -check-prefix=CHECK-NONE %s
 # RUN: llvm-mc -triple=sbf-solana-solana -mcpu=v1 -filetype=obj < %s \
 # RUN:   | llvm-readobj --file-headers - \
 # RUN:   | FileCheck -check-prefix=CHECK-SBFV1 %s
-# RUN: llvm-mc -triple=sbfv1-solana-solana -filetype=obj < %s \
+# RUN: llvm-mc -triple=sbpfv1-solana-solana -filetype=obj < %s \
 # RUN:   | llvm-readobj --file-headers - \
 # RUN:   | FileCheck -check-prefix=CHECK-SBFV1 %s
 # RUN: llvm-mc -triple=sbf-solana-solana -mcpu=v2 -filetype=obj < %s \
 # RUN:   | llvm-readobj --file-headers - \
 # RUN:   | FileCheck -check-prefix=CHECK-SBFV2 %s
-# RUN: llvm-mc -triple=sbfv2-solana-solana -filetype=obj < %s \
+# RUN: llvm-mc -triple=sbpfv2-solana-solana -filetype=obj < %s \
 # RUN:   | llvm-readobj --file-headers - \
 # RUN:   | FileCheck -check-prefix=CHECK-SBFV2 %s
 # RUN: llvm-mc -triple=sbf-solana-solana -mcpu=v3 -filetype=obj < %s \
 # RUN:   | llvm-readobj --file-headers - \
 # RUN:   | FileCheck -check-prefix=CHECK-SBFV3 %s
-# RUN: llvm-mc -triple=sbfv3-solana-solana -filetype=obj < %s \
+# RUN: llvm-mc -triple=sbpfv3-solana-solana -filetype=obj < %s \
 # RUN:   | llvm-readobj --file-headers - \
 # RUN:   | FileCheck -check-prefix=CHECK-SBFV3 %s
 

--- a/llvm/test/MC/SBF/sbf-jmp.s
+++ b/llvm/test/MC/SBF/sbf-jmp.s
@@ -1,5 +1,7 @@
 # RUN: llvm-mc %s -triple=sbf-solana-solana --mcpu=v3 --show-encoding \
 # RUN:     | FileCheck %s --check-prefix=CHECK-ASM-NEW
+# RUN: llvm-mc %s -triple=sbfv3-solana-solana --show-encoding \
+# RUN:     | FileCheck %s --check-prefix=CHECK-ASM-NEW
 # RUN: llvm-mc %s -triple=sbf-solana-solana --show-encoding \
 # RUN:     | FileCheck %s --check-prefix=CHECK-ASM-OLD
 # RUN: llvm-mc %s -triple=sbf-solana-solana --mcpu=v3 -filetype=obj \

--- a/llvm/test/MC/SBF/sbf-jmp.s
+++ b/llvm/test/MC/SBF/sbf-jmp.s
@@ -1,6 +1,6 @@
 # RUN: llvm-mc %s -triple=sbf-solana-solana --mcpu=v3 --show-encoding \
 # RUN:     | FileCheck %s --check-prefix=CHECK-ASM-NEW
-# RUN: llvm-mc %s -triple=sbfv3-solana-solana --show-encoding \
+# RUN: llvm-mc %s -triple=sbpfv3-solana-solana --show-encoding \
 # RUN:     | FileCheck %s --check-prefix=CHECK-ASM-NEW
 # RUN: llvm-mc %s -triple=sbf-solana-solana --show-encoding \
 # RUN:     | FileCheck %s --check-prefix=CHECK-ASM-OLD

--- a/llvm/unittests/TargetParser/TripleTest.cpp
+++ b/llvm/unittests/TargetParser/TripleTest.cpp
@@ -618,21 +618,27 @@ TEST(TripleTest, ParsedIDs) {
   EXPECT_EQ(Triple::SolanaOS, T.getOS());
   EXPECT_EQ(Triple::UnknownEnvironment, T.getEnvironment());
 
-  T = Triple("sbfv1-solana-solana");
+  T = Triple("sbpf-solana-solana");
+  EXPECT_EQ(Triple::sbf, T.getArch());
+  EXPECT_EQ(Triple::Solana, T.getVendor());
+  EXPECT_EQ(Triple::SolanaOS, T.getOS());
+  EXPECT_EQ(Triple::UnknownEnvironment, T.getEnvironment());
+
+  T = Triple("sbpfv1-solana-solana");
   EXPECT_EQ(Triple::sbf, T.getArch());
   EXPECT_EQ(Triple::SBFSubArch_v1, T.getSubArch());
   EXPECT_EQ(Triple::Solana, T.getVendor());
   EXPECT_EQ(Triple::SolanaOS, T.getOS());
   EXPECT_EQ(Triple::UnknownEnvironment, T.getEnvironment());
 
-  T = Triple("sbfv2-solana-solana");
+  T = Triple("sbpfv2-solana-solana");
   EXPECT_EQ(Triple::sbf, T.getArch());
   EXPECT_EQ(Triple::SBFSubArch_v2, T.getSubArch());
   EXPECT_EQ(Triple::Solana, T.getVendor());
   EXPECT_EQ(Triple::SolanaOS, T.getOS());
   EXPECT_EQ(Triple::UnknownEnvironment, T.getEnvironment());
 
-  T = Triple("sbfv3-solana-solana");
+  T = Triple("sbpfv3-solana-solana");
   EXPECT_EQ(Triple::sbf, T.getArch());
   EXPECT_EQ(Triple::SBFSubArch_v3, T.getSubArch());
   EXPECT_EQ(Triple::Solana, T.getVendor());
@@ -646,6 +652,12 @@ TEST(TripleTest, ParsedIDs) {
   EXPECT_EQ(Triple::UnknownEnvironment, T.getEnvironment());
 
   T = Triple("sbf");
+  EXPECT_EQ(Triple::sbf, T.getArch());
+  EXPECT_EQ(Triple::UnknownVendor, T.getVendor());
+  EXPECT_EQ(Triple::UnknownOS, T.getOS());
+  EXPECT_EQ(Triple::UnknownEnvironment, T.getEnvironment());
+
+  T = Triple("sbpf");
   EXPECT_EQ(Triple::sbf, T.getArch());
   EXPECT_EQ(Triple::UnknownVendor, T.getVendor());
   EXPECT_EQ(Triple::UnknownOS, T.getOS());

--- a/llvm/unittests/TargetParser/TripleTest.cpp
+++ b/llvm/unittests/TargetParser/TripleTest.cpp
@@ -618,6 +618,27 @@ TEST(TripleTest, ParsedIDs) {
   EXPECT_EQ(Triple::SolanaOS, T.getOS());
   EXPECT_EQ(Triple::UnknownEnvironment, T.getEnvironment());
 
+  T = Triple("sbfv1-solana-solana");
+  EXPECT_EQ(Triple::sbf, T.getArch());
+  EXPECT_EQ(Triple::SBFSubArch_v1, T.getSubArch());
+  EXPECT_EQ(Triple::Solana, T.getVendor());
+  EXPECT_EQ(Triple::SolanaOS, T.getOS());
+  EXPECT_EQ(Triple::UnknownEnvironment, T.getEnvironment());
+
+  T = Triple("sbfv2-solana-solana");
+  EXPECT_EQ(Triple::sbf, T.getArch());
+  EXPECT_EQ(Triple::SBFSubArch_v2, T.getSubArch());
+  EXPECT_EQ(Triple::Solana, T.getVendor());
+  EXPECT_EQ(Triple::SolanaOS, T.getOS());
+  EXPECT_EQ(Triple::UnknownEnvironment, T.getEnvironment());
+
+  T = Triple("sbfv3-solana-solana");
+  EXPECT_EQ(Triple::sbf, T.getArch());
+  EXPECT_EQ(Triple::SBFSubArch_v3, T.getSubArch());
+  EXPECT_EQ(Triple::Solana, T.getVendor());
+  EXPECT_EQ(Triple::SolanaOS, T.getOS());
+  EXPECT_EQ(Triple::UnknownEnvironment, T.getEnvironment());
+
   T = Triple("sbf-unknown-unknown");
   EXPECT_EQ(Triple::sbf, T.getArch());
   EXPECT_EQ(Triple::UnknownVendor, T.getVendor());


### PR DESCRIPTION
Rustc ships with pre-compiled std lib `.rlib` files, so when we choose SBF v1, v2, or v3 CPUs, we need to manually rebuild them using rust arguments `-Zbuild-std=std,panic_abort`.

Building them on the fly generates less optimized code. To avoid such a problem, I'll split the SBF target in Rustc into four sub-targets: `sbf-solana-solana`, `sbfv1-solana-solana`, `sbfv2-solana-solana` and `sbfv3-solana-solana`.

As compiler-builtins needs clang to create optimized code, the update in this PR process the new target in LLVM as a sub-architecture type for SBF. In its target definition, the sub-architecture is equivalent to the CPU types v1, v2 and v3.