### PR TITLE
[SOL] Disable ALU32 for SBFPv2 and SBPFv3

### DIFF
--- a/llvm/lib/Target/SBF/SBFTargetFeatures.td
+++ b/llvm/lib/Target/SBF/SBFTargetFeatures.td
@@ -60,7 +60,7 @@ def : Proc<"generic", []>;
 def : Proc<"v1", [FeatureDynamicFrames, FeatureStoreImm, FeatureJumpExt]>;
 def : Proc<"v2", [FeatureDynamicFrames, FeatureStoreImm, FeatureJumpExt, FeatureDisableLddw,
                   FeatureNewMemEncoding, FeatureCallxRegSrc, FeaturePqrInstr, FeatureExplicitSext,
-                  FeatureDisableNeg, FeatureReverseSubImm, ALU32]>;
+                  FeatureDisableNeg, FeatureReverseSubImm]>;
 def : Proc<"v3", [FeatureDynamicFrames, FeatureStoreImm, FeatureJumpExt, FeatureDisableLddw,
                   FeatureNewMemEncoding, FeatureCallxRegSrc, FeaturePqrInstr, FeatureExplicitSext,
-                  FeatureDisableNeg, FeatureReverseSubImm, ALU32, FeatureStaticSyscalls, FeatureRelocAbs64]>;
+                  FeatureDisableNeg, FeatureReverseSubImm, FeatureStaticSyscalls, FeatureRelocAbs64]>;

--- a/llvm/test/CodeGen/SBF/32-bit-subreg-alu.ll
+++ b/llvm/test/CodeGen/SBF/32-bit-subreg-alu.ll
@@ -1,5 +1,5 @@
 ; RUN: llc -O2 -march=sbf -mattr=+alu32 < %s | FileCheck --check-prefixes=CHECK,CHECK-V0 %s
-; RUN: llc -O2 -march=sbf -mcpu=v3 < %s | FileCheck --check-prefixes=CHECK,CHECK-V3 %s
+; RUN: llc -O2 -march=sbf -mcpu=v3 -mattr=+alu32 < %s | FileCheck --check-prefixes=CHECK,CHECK-V3 %s
 ;
 ; int mov(int a)
 ; {

--- a/llvm/test/CodeGen/SBF/32-bit-subreg-peephole.ll
+++ b/llvm/test/CodeGen/SBF/32-bit-subreg-peephole.ll
@@ -1,4 +1,4 @@
-; RUN: llc -O2 -march=sbf -mcpu=v2 < %s | FileCheck %s
+; RUN: llc -O2 -march=sbf -mcpu=v2 -mattr=+alu32 < %s | FileCheck %s
 ;
 ; long long select_u(unsigned a, unsigned b, long long c, long long d)
 ; {

--- a/llvm/test/CodeGen/SBF/cc_args.ll
+++ b/llvm/test/CodeGen/SBF/cc_args.ll
@@ -1,5 +1,5 @@
 ; RUN: llc < %s -march=sbf -show-mc-encoding | FileCheck --check-prefix=CHECK-v0 %s
-; RUN: llc < %s -march=sbf -mcpu=v2 -show-mc-encoding | FileCheck --check-prefix=CHECK-v2 %s
+; RUN: llc < %s -march=sbf -mcpu=v2 -mattr=+alu32 -show-mc-encoding | FileCheck --check-prefix=CHECK-v2 %s
 
 define void @test() #0 {
 entry:

--- a/llvm/test/CodeGen/SBF/many_args_value_size.ll
+++ b/llvm/test/CodeGen/SBF/many_args_value_size.ll
@@ -1,5 +1,5 @@
-; RUN: llc -march=sbf -mcpu=v2 < %s | FileCheck %s
-; RUN: llc -mtriple=sbpfv2-solana-solana < %s | FileCheck %s
+; RUN: llc -march=sbf -mcpu=v2 -mattr=+alu32 < %s | FileCheck %s
+; RUN: llc -mtriple=sbpfv2-solana-solana -mattr=+alu32 < %s | FileCheck %s
 
 define i64 @test_func(i64 %a, i64 %b, i64 %c, i64 %d, i64 %e) {
 start:

--- a/llvm/test/CodeGen/SBF/mulh.ll
+++ b/llvm/test/CodeGen/SBF/mulh.ll
@@ -1,4 +1,4 @@
-; RUN: llc -O2 -march=sbf -mcpu=v2 < %s | FileCheck %s
+; RUN: llc -O2 -march=sbf -mcpu=v2 -mattr=+alu32 < %s | FileCheck %s
 
 define dso_local i32 @test_32_unsigned(i32 noundef %a, i32 noundef %b) {
 entry:

--- a/llvm/test/CodeGen/SBF/objdump_cond_op.ll
+++ b/llvm/test/CodeGen/SBF/objdump_cond_op.ll
@@ -1,4 +1,4 @@
-; RUN: llc -march=sbf -mcpu=v2 -filetype=obj -o - %s | llvm-objdump -d - | FileCheck %s
+; RUN: llc -march=sbf -mcpu=v2 -mattr=+alu32 -filetype=obj -o - %s | llvm-objdump -d - | FileCheck %s
 
 ; Source Code:
 ; int gbl;
@@ -33,9 +33,9 @@ define i32 @test(i32, i32) local_unnamed_addr #0 {
   %10 = load i32, i32* @gbl, align 4
   br i1 %9, label %15, label %11
 
-; CHECK: mov32 w1, 0x0
+; CHECK: mov32 r1, 0x0
 ; CHECK: hor64 r1, 0x0
-; CHECK: ldxw w0, [r1 + 0x0]
+; CHECK: ldxw r0, [r1 + 0x0]
 ; CHECK: lmul32 w0, w0
 ; CHECK: lsh32 w0, 0x1
 ; CHECK: ja +0x5 <LBB0_4>
@@ -45,9 +45,9 @@ define i32 @test(i32, i32) local_unnamed_addr #0 {
   br label %13
 
 ; CHECK-LABEL: <LBB0_2>:
-; CHECK: mov32 w3, 0x0
+; CHECK: mov32 r3, 0x0
 ; CHECK: hor64 r3, 0x0
-; CHECK: ldxw w0, [r3 + 0x0]
+; CHECK: ldxw r0, [r3 + 0x0]
 ; CHECK: jeq r1, r2, +0x4 <LBB0_5>
 ; CHECK: lsh32 w0, 0x2
 
@@ -56,9 +56,9 @@ define i32 @test(i32, i32) local_unnamed_addr #0 {
   store i32 %14, i32* @gbl, align 4
   br label %15
 ; CHECK-LABEL: <LBB0_4>:
-; CHECK: mov32 w1, 0x0
+; CHECK: mov32 r1, 0x0
 ; CHECK: hor64 r1, 0x0
-; CHECK: stxw [r1 + 0x0], w0
+; CHECK: stxw [r1 + 0x0], r0
 
 ; <label>:15:                                     ; preds = %8, %13
   %16 = phi i32 [ %14, %13 ], [ %10, %8 ]

--- a/llvm/test/CodeGen/SBF/objdump_imm_hex.ll
+++ b/llvm/test/CodeGen/SBF/objdump_imm_hex.ll
@@ -1,6 +1,6 @@
-; RUN: llc -march=sbf -mcpu=v2 -filetype=obj -o - %s | llvm-objdump -d - | FileCheck --check-prefix=CHECK-DEC %s
-; RUN: llc -march=sbf -mcpu=v2 -filetype=obj -o - %s | llvm-objdump -d --print-imm-hex - | FileCheck --check-prefix=CHECK-HEX %s
-; RUN: llc < %s -march=sbf -mcpu=v2 -show-mc-encoding | FileCheck --check-prefix=CHECK-REL %s
+; RUN: llc -march=sbf -mcpu=v2 -mattr=+alu32 -filetype=obj -o - %s | llvm-objdump -d - | FileCheck --check-prefix=CHECK-DEC %s
+; RUN: llc -march=sbf -mcpu=v2 -mattr=+alu32 -filetype=obj -o - %s | llvm-objdump -d --print-imm-hex - | FileCheck --check-prefix=CHECK-HEX %s
+; RUN: llc < %s -march=sbf -mcpu=v2 -mattr=+alu32 -show-mc-encoding | FileCheck --check-prefix=CHECK-REL %s
 
 ; Source Code:
 ; int gbl;
@@ -26,17 +26,17 @@ define i32 @test(i64, i64) local_unnamed_addr #0 {
 ; CHECK-LABEL: test
   %3 = icmp eq i64 %0, -6067004223159161907
   br i1 %3, label %4, label %8
-; CHECK-DEC: b4 03 00 00 cd ab cd ab	mov32 w3, -0x54325433
+; CHECK-DEC: b4 03 00 00 cd ab cd ab	mov32 r3, -0x54325433
 ; CHECK-DEC: f7 03 00 00 cd ab cd ab	hor64 r3, -0x54325433
 ; CHECK-DEC: 5d 31 07 00 00 00 00 00         jne r1, r3, +0x7
-; CHECK-HEX: b4 03 00 00 cd ab cd ab	mov32 w3, -0x54325433
+; CHECK-HEX: b4 03 00 00 cd ab cd ab	mov32 r3, -0x54325433
 ; CHECK-HEX: f7 03 00 00 cd ab cd ab	hor64 r3, -0x54325433
 ; CHECK-HEX: 5d 31 07 00 00 00 00 00         jne r1, r3, +0x7
 
 ; <label>:4:                                      ; preds = %2
-; CHECK-DEC: b4 01 00 00 00 00 00 00	mov32 w1, 0x0
+; CHECK-DEC: b4 01 00 00 00 00 00 00	mov32 r1, 0x0
 ; CHECK-DEC: f7 01 00 00 00 00 00 00	hor64 r1, 0x0
-; CHECK-HEX: b4 01 00 00 00 00 00 00	mov32 w1, 0x0
+; CHECK-HEX: b4 01 00 00 00 00 00 00	mov32 r1, 0x0
 ; CHECK-HEX: f7 01 00 00 00 00 00 00	hor64 r1, 0x0
 ; CHECK-REL:   fixup A - offset: 0, value: gbl, kind: FK_SecRel_8
   %5 = load i32, i32* @gbl, align 4
@@ -48,16 +48,16 @@ define i32 @test(i64, i64) local_unnamed_addr #0 {
 
 ; <label>:8:                                      ; preds = %2
   %9 = icmp eq i64 %1, 188899839028173
-; CHECK-DEC: b4 01 00 00 cd ab cd ab	mov32 w1, -0x54325433
+; CHECK-DEC: b4 01 00 00 cd ab cd ab	mov32 r1, -0x54325433
 ; CHECK-DEC: f7 01 00 00 cd ab 00 00	hor64 r1, 0xabcd
-; CHECK-HEX: b4 01 00 00 cd ab cd ab	mov32 w1, -0x54325433
+; CHECK-HEX: b4 01 00 00 cd ab cd ab	mov32 r1, -0x54325433
 ; CHECK-HEX: f7 01 00 00 cd ab 00 00	hor64 r1, 0xabcd
   br i1 %9, label %10, label %16
 
 ; <label>:10:                                     ; preds = %8
-; CHECK-DEC: b4 01 00 00 00 00 00 00	mov32 w1, 0x0
+; CHECK-DEC: b4 01 00 00 00 00 00 00	mov32 r1, 0x0
 ; CHECK-DEC: f7 01 00 00 00 00 00 00	hor64 r1, 0x0
-; CHECK-HEX: b4 01 00 00 00 00 00 00	mov32 w1, 0x0
+; CHECK-HEX: b4 01 00 00 00 00 00 00	mov32 r1, 0x0
 ; CHECK-HEX: f7 01 00 00 00 00 00 00	hor64 r1, 0x0
 ; CHECK-REL: fixup A - offset: 0, value: gbl, kind: FK_SecRel_8
   %11 = load i32, i32* @gbl, align 4
@@ -68,8 +68,8 @@ define i32 @test(i64, i64) local_unnamed_addr #0 {
   %14 = phi i32 [ %12, %10 ], [ %7, %4 ]
   %15 = phi i32 [ 2, %10 ], [ 1, %4 ]
   store i32 %14, i32* @gbl, align 4
-; CHECK-DEC: 8f 12 00 00 00 00 00 00         stxw [r2 + 0x0], w1
-; CHECK-HEX: 8f 12 00 00 00 00 00 00         stxw [r2 + 0x0], w1
+; CHECK-DEC: 8f 12 00 00 00 00 00 00         stxw [r2 + 0x0], r1
+; CHECK-HEX: 8f 12 00 00 00 00 00 00         stxw [r2 + 0x0], r1
   br label %16
 
 ; <label>:16:                                     ; preds = %13, %8

--- a/llvm/test/CodeGen/SBF/objdump_static_var.ll
+++ b/llvm/test/CodeGen/SBF/objdump_static_var.ll
@@ -1,4 +1,4 @@
-; RUN: llc -march=sbf -mcpu=v2 -filetype=obj -o - %s | llvm-objdump -dr - | FileCheck --check-prefix=CHECK %s
+; RUN: llc -march=sbf -mcpu=v2 -mattr=+alu32 -filetype=obj -o - %s | llvm-objdump -dr - | FileCheck --check-prefix=CHECK %s
 
 ; src:
 ;   static volatile long a = 2;
@@ -10,15 +10,15 @@
 ; Function Attrs: norecurse nounwind
 define dso_local i32 @test() local_unnamed_addr #0 {
   %1 = load volatile i64, i64* @a, align 8, !tbaa !2
-; CHECK: mov32 w1, 0x0
+; CHECK: mov32 r1, 0x0
 ; CHECK: R_SBF_64_64	a
 ; CHECK: hor64 r1, 0x0
 ; CHECK: ldxdw r1, [r1 + 0x0]
   %2 = load volatile i32, i32* @b, align 4, !tbaa !6
-; CHECK: mov32 w2, 0x0
+; CHECK: mov32 r2, 0x0
 ; CHECK: R_SBF_64_64	b
 ; CHECK: hor64 r2, 0x0
-; CHECK: ldxw w0, [r2 + 0x0]
+; CHECK: ldxw r0, [r2 + 0x0]
   %3 = trunc i64 %1 to i32
   %4 = add i32 %2, %3
 ; CHECK: add32 w0, w1

--- a/llvm/test/CodeGen/SBF/sdiv.ll
+++ b/llvm/test/CodeGen/SBF/sdiv.ll
@@ -1,5 +1,5 @@
 ; RUN: llc -march=sbf < %s | FileCheck %s -check-prefixes=CHECK-SBF
-; RUN: llc -march=sbf -mcpu=v2 < %s | FileCheck %s -check-prefixes=CHECK-SBFV2
+; RUN: llc -march=sbf -mcpu=v2 -mattr=+alu32 < %s | FileCheck %s -check-prefixes=CHECK-SBFV2
 
 ; Function Attrs: norecurse nounwind readnone
 define i32 @test(i32 %len) #0 {

--- a/llvm/test/CodeGen/SBF/spill-alu32.ll
+++ b/llvm/test/CodeGen/SBF/spill-alu32.ll
@@ -1,4 +1,4 @@
-; RUN: llc -march=sbf -mcpu=v2 < %s | FileCheck %s
+; RUN: llc -march=sbf -mcpu=v2 -mattr=+alu32 < %s | FileCheck %s
 ;
 ; Source code:
 ;   void foo(int, int, int, long, int);

--- a/llvm/test/CodeGen/SBF/sub_reversed_immediate.ll
+++ b/llvm/test/CodeGen/SBF/sub_reversed_immediate.ll
@@ -1,5 +1,5 @@
 ; RUN: llc < %s -march=sbf -mattr=+alu32 | FileCheck  --check-prefix=CHECK-v1 %s
-; RUN: llc < %s -march=sbf -mcpu=v2 | FileCheck  --check-prefix=CHECK-v2 %s
+; RUN: llc < %s -march=sbf -mcpu=v2 -mattr=+alu32 | FileCheck  --check-prefix=CHECK-v2 %s
 
 
 ; Function Attrs: norecurse nounwind readnone


### PR DESCRIPTION
Even though ALU32 instructions are now properly working with explicit sign extension, code generation for them isn't optimal, leading to generally larger programs.

I believe the cause is that new truncation operations and jumps utilize more registers, requiring even more operations to achieve the same thing.