### PR TITLE
[SOL] Use no-op for anyext

### DIFF
--- a/llvm/lib/Target/SBF/SBFInstrInfo.td
+++ b/llvm/lib/Target/SBF/SBFInstrInfo.td
@@ -1275,13 +1275,8 @@ def : Pat<(i32 (trunc GPR:$src)),
 def : Pat<(i32 (trunc GPR:$src)),
           (i32 (EXTRACT_SUBREG GPR:$src, sub_32))>, Requires<[SBFNoExplicitSignExt]>;
 
-// SBFv2 anyext
 def : Pat<(i64 (anyext GPR32:$src)),
-          (MOV_32_64 GPR32:$src)>, Requires<[SBFExplicitSignExt]>;
-
-// SBFv1 anyext
-def : Pat<(i64 (anyext GPR32:$src)),
-          (INSERT_SUBREG (i64 (IMPLICIT_DEF)), GPR32:$src, sub_32)>, Requires<[SBFNoExplicitSignExt]>;
+          (INSERT_SUBREG (i64 (IMPLICIT_DEF)), GPR32:$src, sub_32)>;
 
 class STORE32_V1<SBFWidthModifer SizeOp, string Mnemonic>
     : TYPE_LD_ST<SBF_MEM.Value, SizeOp.Value,


### PR DESCRIPTION
When LLVM target independent code generation emits an `anyext` instruction, we extend a value and we don't care about the high bits. In that case, we can simply do a no-op instead of using `mov32`.

In large programs (around 200kb), this action can save us 1kb.