### PR TITLE
[SOL] Set linker configuration variables based on the flag

### DIFF
--- a/lld/ELF/Arch/SBF.cpp
+++ b/lld/ELF/Arch/SBF.cpp
@@ -35,12 +35,27 @@ public:
 };
 } // namespace
 
+static uint32_t getEFlags(InputFile *file) {
+  if (config->ekind == ELF64BEKind)
+    return cast<ObjFile<ELF64BE>>(file)->getObj().getHeader().e_flags;
+  return cast<ObjFile<ELF64LE>>(file)->getObj().getHeader().e_flags;
+}
+
+static uint32_t getSampleEFlag() {
+  if (ctx.objectFiles.empty())
+    return 0;
+  InputFile * f = ctx.objectFiles[0];
+  return getEFlags(f);
+}
+
 SBF::SBF() {
   relativeRel = R_SBF_64_RELATIVE;
   symbolicRel = R_SBF_64_64;
-  defaultCommonPageSize = 8;
-  defaultMaxPageSize = 8;
-  defaultImageBase = 0;
+  if (getSampleEFlag() == 0x3) {
+    defaultCommonPageSize = 8;
+    defaultMaxPageSize = 8;
+    defaultImageBase = 0;
+  }
 }
 
 RelExpr SBF::getRelExpr(RelType type, const Symbol &s,
@@ -115,12 +130,6 @@ void SBF::relocate(uint8_t *loc, const Relocation &rel, uint64_t val) const {
     default:
       error(getErrorLocation(loc) + "unrecognized reloc " + toString(rel.type));
   }
-}
-
-static uint32_t getEFlags(InputFile *file) {
-  if (config->ekind == ELF64BEKind)
-    return cast<ObjFile<ELF64BE>>(file)->getObj().getHeader().e_flags;
-  return cast<ObjFile<ELF64LE>>(file)->getObj().getHeader().e_flags;
 }
 
 uint32_t SBF::calcEFlags() const {


### PR DESCRIPTION
**Problem**

In SBPF versions from v0 to v2, if we set the page size to 8, the compiler output is correct. However, if we subsequently use `llvm-objcopy` to strip extra data (like we do in `cargo-build-sbf`), the offset and virtual address of sections will diverge, since the alignment is now 8 and not 1024 as it was previously. This divergence triggers an error in the sbpf ELF loader:

https://github.com/anza-xyz/sbpf/blob/615f120f70d3ef387aab304c5cdf66ad32dae194/src/elf.rs#L649

**Solution**

Set the new page alignment variables only for SBPFv3.