### PR TITLE
[SOL] Fix stack arguments store chain

### DIFF
--- a/llvm/lib/Target/SBF/SBFISelLowering.cpp
+++ b/llvm/lib/Target/SBF/SBFISelLowering.cpp
@@ -524,10 +524,6 @@ SDValue SBFTargetLowering::LowerCall(TargetLowering::CallLoweringInfo &CLI,
 
       assert(VA.isMemLoc());
 
-      EVT PtrVT = DAG.getTargetLoweringInfo().getPointerTy(DAG.getDataLayout());
-      SDValue DstAddr;
-      MachinePointerInfo DstInfo;
-      int FrameIndex;
       int64_t Offset = static_cast<int64_t>(VA.getLocMemOffset());
       uint64_t Size = VA.getLocVT().getFixedSizeInBits() / 8;
       if (Subtarget->getHasDynamicFrames()) {
@@ -537,11 +533,11 @@ SDValue SBFTargetLowering::LowerCall(TargetLowering::CallLoweringInfo &CLI,
         Offset += Size;
       }
 
-      FrameIndex = MF.getFrameInfo().CreateFixedObject(
+      int FrameIndex = MF.getFrameInfo().CreateFixedObject(
           Size, Offset, false);
       SBFFuncInfo->storeFrameIndexArgument(FrameIndex);
-      DstAddr = DAG.getFrameIndex(FrameIndex, PtrVT);
-      DstInfo = MachinePointerInfo::getFixedStack(MF, FrameIndex, Offset);
+      SDValue DstAddr = DAG.getFrameIndex(FrameIndex, PtrVT);
+      MachinePointerInfo DstInfo = MachinePointerInfo::getFixedStack(MF, FrameIndex, Offset);
       SDValue Store = DAG.getStore(Chain, CLI.DL, Arg, DstAddr, DstInfo);
       MemOpChain.push_back(Store);
     }

--- a/llvm/lib/Target/SBF/SBFISelLowering.cpp
+++ b/llvm/lib/Target/SBF/SBFISelLowering.cpp
@@ -473,9 +473,11 @@ SDValue SBFTargetLowering::LowerCall(TargetLowering::CallLoweringInfo &CLI,
   SmallVector<std::pair<unsigned, SDValue>, MaxArgs> RegsToPass;
 
   // Walk arg assignments
-  bool HasStackArgs = false;
-  unsigned e, i, ae = ArgLocs.size();
-  for (i = 0, e = ae; i != e; ++i) {
+  unsigned i;
+  SmallVector<SDValue, 8> MemOpChain;
+  SBFFunctionInfo * SBFFuncInfo = MF.getInfo<SBFFunctionInfo>();
+
+  for (i = 0; i < ArgLocs.size(); i++) {
     CCValAssign &VA = ArgLocs[i];
     SDValue Arg = OutVals[i];
 
@@ -496,33 +498,12 @@ SDValue SBFTargetLowering::LowerCall(TargetLowering::CallLoweringInfo &CLI,
       break;
     }
 
-    if (VA.isMemLoc()) {
-      HasStackArgs = true;
-      break;
-    }
-
     // Push arguments into RegsToPass vector
     if (VA.isRegLoc())
       RegsToPass.push_back(std::make_pair(VA.getLocReg(), Arg));
-    else
-      llvm_unreachable("call arg pass bug");
-  }
-
-  SDValue InGlue;
-
-  SmallVector<SDValue, 8> MemOpChain;
-  if (HasStackArgs) {
-    SBFFunctionInfo * SBFFuncInfo = MF.getInfo<SBFFunctionInfo>();
-    // Stack arguments have to be walked in reverse order by inserting
-    // chained stores, this ensures their order is not changed by the scheduler
-    // and that the push instruction sequence generated is correct, otherwise they
-    // can be freely intermixed.
-    for (ae = i, i = ArgLocs.size(); i != ae; --i) {
-      unsigned Loc = i - 1;
-      CCValAssign &VA = ArgLocs[Loc];
-      SDValue Arg = OutVals[Loc];
-
-      assert(VA.isMemLoc());
+    else if (VA.isMemLoc()) {
+      CCValAssign &VA = ArgLocs[i];
+      SDValue Arg = OutVals[i];
 
       int64_t Offset = static_cast<int64_t>(VA.getLocMemOffset());
       uint64_t Size = VA.getLocVT().getFixedSizeInBits() / 8;
@@ -540,11 +521,15 @@ SDValue SBFTargetLowering::LowerCall(TargetLowering::CallLoweringInfo &CLI,
       MachinePointerInfo DstInfo = MachinePointerInfo::getFixedStack(MF, FrameIndex, Offset);
       SDValue Store = DAG.getStore(Chain, CLI.DL, Arg, DstAddr, DstInfo);
       MemOpChain.push_back(Store);
-    }
 
-    if (!MemOpChain.empty())
-      Chain = DAG.getNode(ISD::TokenFactor, CLI.DL, MVT::Other, MemOpChain);
+    } else
+      llvm_unreachable("call arg pass bug");
+  }
 
+  SDValue InGlue;
+
+  if (!MemOpChain.empty()) {
+    Chain = DAG.getNode(ISD::TokenFactor, CLI.DL, MVT::Other, MemOpChain);
     if (!Subtarget->getHasDynamicFrames()) {
       // Pass the current stack frame pointer via SBF::R5, gluing the
       // instruction to instructions passing the first 4 arguments in
@@ -555,7 +540,6 @@ SDValue SBFTargetLowering::LowerCall(TargetLowering::CallLoweringInfo &CLI,
       Chain = DAG.getCopyToReg(Chain, CLI.DL, SBF::R5, FramePtr, InGlue);
       InGlue = Chain.getValue(1);
     }
-
   }
 
   // Build a sequence of copy-to-reg nodes chained together with token chain and
@@ -587,7 +571,7 @@ SDValue SBFTargetLowering::LowerCall(TargetLowering::CallLoweringInfo &CLI,
   for (auto &Reg : RegsToPass)
     Ops.push_back(DAG.getRegister(Reg.first, Reg.second.getValueType()));
 
-  if (HasStackArgs && !Subtarget->getHasDynamicFrames()) {
+  if (!MemOpChain.empty() && !Subtarget->getHasDynamicFrames()) {
     Ops.push_back(DAG.getRegister(SBF::R5, MVT::i64));
   }
 

--- a/llvm/lib/Target/SBF/SBFISelLowering.cpp
+++ b/llvm/lib/Target/SBF/SBFISelLowering.cpp
@@ -510,6 +510,7 @@ SDValue SBFTargetLowering::LowerCall(TargetLowering::CallLoweringInfo &CLI,
 
   SDValue InGlue;
 
+  SmallVector<SDValue, 8> MemOpChain;
   if (HasStackArgs) {
     SBFFunctionInfo * SBFFuncInfo = MF.getInfo<SBFFunctionInfo>();
     // Stack arguments have to be walked in reverse order by inserting
@@ -541,8 +542,12 @@ SDValue SBFTargetLowering::LowerCall(TargetLowering::CallLoweringInfo &CLI,
       SBFFuncInfo->storeFrameIndexArgument(FrameIndex);
       DstAddr = DAG.getFrameIndex(FrameIndex, PtrVT);
       DstInfo = MachinePointerInfo::getFixedStack(MF, FrameIndex, Offset);
-      Chain = DAG.getStore(Chain, CLI.DL, Arg, DstAddr, DstInfo);
+      SDValue Store = DAG.getStore(Chain, CLI.DL, Arg, DstAddr, DstInfo);
+      MemOpChain.push_back(Store);
     }
+
+    if (!MemOpChain.empty())
+      Chain = DAG.getNode(ISD::TokenFactor, CLI.DL, MVT::Other, MemOpChain);
 
     if (!Subtarget->getHasDynamicFrames()) {
       // Pass the current stack frame pointer via SBF::R5, gluing the

--- a/llvm/test/CodeGen/SBF/many_args1.ll
+++ b/llvm/test/CodeGen/SBF/many_args1.ll
@@ -3,10 +3,10 @@
 ; Function Attrs: nounwind uwtable
 define i32 @foo(i32 %a, i32 %b, i32 %c) #0 {
 ; CHECK-LABEL: foo:
-; CHECK: mov64 r4, 2
-; CHECK: stxdw [r10 - 4096], r4
 ; CHECK: mov64 r4, 3
 ; CHECK: stxdw [r10 - 4088], r4
+; CHECK: mov64 r4, 2
+; CHECK: stxdw [r10 - 4096], r4
 ; CHECK: mov64 r5, r10
 ; CHECK: mov64 r4, 1
 ; CHECK: call bar

--- a/llvm/test/CodeGen/SBF/many_args_new_conv.ll
+++ b/llvm/test/CodeGen/SBF/many_args_new_conv.ll
@@ -11,8 +11,8 @@ entry:
 ; CHECK-NOT: add64 r10
 
 ; Saving arguments on the stack
-; CHECK: stdw [r10 - 32], 55
 ; CHECK: stdw [r10 - 40], 60
+; CHECK: stdw [r10 - 32], 55
 ; CHECK: stdw [r10 - 24], 50
 ; CHECK: stdw [r10 - 16], 4
 ; CHECK: stdw [r10 - 8], 3
@@ -32,10 +32,10 @@ define i32 @caller_alloca(i32 %a, i32 %b, i32 %c) #0 {
 
 ; Saving arguments in the callee's frame
 
-; Offset in the callee: frame_size - 32
-; CHECK: stdw [r10 - 32], 55
 ; Offset in the callee: frame_size - 40
 ; CHECK: stdw [r10 - 40], 60
+; Offset in the callee: frame_size - 32
+; CHECK: stdw [r10 - 32], 55
 ; Offset in the callee: frame_size - 24
 ; CHECK: stdw [r10 - 24], 50
 ; Offset in the callee: frame_size - 16

--- a/llvm/test/CodeGen/SBF/many_args_value_size.ll
+++ b/llvm/test/CodeGen/SBF/many_args_value_size.ll
@@ -5,8 +5,8 @@ define i64 @test_func(i64 %a, i64 %b, i64 %c, i64 %d, i64 %e) {
 start:
 ; CHECK-LABEL: test_func:
 
-; CHECK: stw [r10 - 20], 300
 ; CHECK: stdw [r10 - 32], 5400
+; CHECK: stw [r10 - 20], 300
 ; CHECK: stw [r10 - 12], 65516
 ; CHECK: stw [r10 - 4], 5
 

--- a/llvm/test/CodeGen/SBF/stack_args_store_chain.ll
+++ b/llvm/test/CodeGen/SBF/stack_args_store_chain.ll
@@ -1,0 +1,34 @@
+; RUN: llc < %s -march=sbf -mcpu=v2 | FileCheck %s
+
+
+declare void @do_something(ptr, ptr, ptr, ptr, ptr);
+declare void @test(ptr dead_on_unwind noalias nocapture noundef writable align 8 dereferenceable(24) %_0, ptr noalias noundef readonly align 1 dereferenceable(32) %pool_account_key, ptr noalias nocapture noundef readonly align 8 dereferenceable(48) %token_program, ptr noalias nocapture noundef readonly align 8 dereferenceable(48) %mint, ptr noalias nocapture noundef readonly align 8 dereferenceable(48) %destination, ptr noalias nocapture noundef readonly align 8 dereferenceable(48) %authority, i8 noundef %bump_seed, i64 noundef %amount);
+
+define void @func() {
+; CHECK-LABEL: func
+   %185 = alloca [24 x i8], align 8
+   %186 = alloca [48 x i8], align 8
+   %187 = alloca [48 x i8], align 8
+   %188 = alloca [48 x i8], align 8
+   %189 = alloca [48 x i8], align 8
+
+   call void @do_something(ptr %185, ptr %186, ptr %187, ptr %188, ptr %189)
+   %200 = load ptr, ptr %185, align 8
+   %bump_seed = load i8, ptr %188, align 1
+   %other = load i64, ptr %187, align 8
+
+; CHECK: ldxdw r2, [r10 + 232]
+; CHECK: ldxb w1, [r10 + 88]
+; CHECK: ldxdw r3, [r10 + 136]
+
+; CHECK: stxdw [r10 - 24], r3
+
+; The stxw [r10 - 12] store disappears if we use chained stores.
+
+; CHECK: stxw [r10 - 12], w1
+; CHECK: stxdw [r10 - 8], r7
+
+   call void @test(ptr noalias nocapture noundef nonnull align 8 dereferenceable(24) %185, ptr noalias noundef nonnull readonly align 1 dereferenceable(32) %200, ptr noalias nocapture noundef nonnull align 8 dereferenceable(48) %186, ptr noalias nocapture noundef nonnull align 8 dereferenceable(48) %187, ptr noalias nocapture noundef nonnull align 8 dereferenceable(48) %188, ptr noalias nocapture noundef nonnull align 8 dereferenceable(48) %189, i8 noundef %bump_seed, i64 noundef %other)
+
+   ret void
+}


### PR DESCRIPTION
**Problem**

The code written for storing function arguments in the stack (https://github.com/anza-xyz/llvm-project/commit/ebe29e738970e37be10473a4126c3a30b0405a6e) used a hack to avoid the target independent code generation from parallelizing and merging store operations. It worked well for SBPFv0 and was unnoticed until recently.

The PR https://github.com/anza-xyz/agave/pull/5606 failed on test with SBPFv2 due to the hack not working for storing 1 byte together with 8 bytes. LLVM tried to parallelize the store and removed the 1 byte store.

**Solution**

I remove the hack from the SBPF target. Instead of chaining stores when saving function arguments, we create the store node in the DAG, and merge them with a special node `TOKEN_FACTOR`, which signals the stores are independent of each other and prevents merging or paralleling them.

I also refactored the code (see the two extra commits), since it was too unnecessarily complex.