### PR TITLE
[SOL] Add v4 CPU type

### DIFF
--- a/lldb/include/lldb/Utility/ArchSpec.h
+++ b/lldb/include/lldb/Utility/ArchSpec.h
@@ -111,6 +111,7 @@ public:
     eSBFSubType_sbfv1,
     eSBFSubType_sbfv2,
     eSBFSubType_sbfv3,
+    eSBFSubType_sbfv4,
   };
 
   enum RISCVSubType {
@@ -240,6 +241,7 @@ public:
     eCore_sbfv1,
     eCore_sbfv2,
     eCore_sbfv3,
+    eCore_sbfv4,
 
     kNumCores,
 

--- a/lldb/source/Plugins/ObjectFile/ELF/ObjectFileELF.cpp
+++ b/lldb/source/Plugins/ObjectFile/ELF/ObjectFileELF.cpp
@@ -258,6 +258,8 @@ static uint32_t sbfVariantFromElfFlags(const elf::ELFHeader &header) {
     return ArchSpec::eSBFSubType_sbfv2;
   case llvm::ELF::EF_SBF_V3:
     return ArchSpec::eSBFSubType_sbfv3;
+  case llvm::ELF::EF_SBF_V4:
+    return ArchSpec::eSBFSubType_sbfv4;
   default:
     return ArchSpec::eSBFSubType_sbfv0;
   }

--- a/lldb/source/Utility/ArchSpec.cpp
+++ b/lldb/source/Utility/ArchSpec.cpp
@@ -245,6 +245,7 @@ static const CoreDefinition g_core_definitions[] = {
     {eByteOrderLittle, 8, 8, 8, llvm::Triple::sbf, ArchSpec::eCore_sbfv1, "sbfv1"},
     {eByteOrderLittle, 8, 8, 8, llvm::Triple::sbf, ArchSpec::eCore_sbfv2, "sbfv2"},
     {eByteOrderLittle, 8, 8, 8, llvm::Triple::sbf, ArchSpec::eCore_sbfv3, "sbfv3"},
+    {eByteOrderLittle, 8, 8, 8, llvm::Triple::sbf, ArchSpec::eCore_sbfv4, "sbfv4"},
 };
 
 // Ensure that we have an entry in the g_core_definitions for each core. If you
@@ -439,6 +440,8 @@ static const ArchDefinitionEntry g_elf_arch_entries[] = {
      0xFFFFFFFFu, 0xFFFFFFFFu}, // sbfv2
     {ArchSpec::eCore_sbfv3, llvm::ELF::EM_SBF, ArchSpec::eSBFSubType_sbfv3,
      0xFFFFFFFFu, 0xFFFFFFFFu}, // sbfv3
+    {ArchSpec::eCore_sbfv4, llvm::ELF::EM_SBF, ArchSpec::eSBFSubType_sbfv4,
+      0xFFFFFFFFu, 0xFFFFFFFFu}, // sbfv3
 };
 
 static const ArchDefinition g_elf_arch_def = {

--- a/llvm/include/llvm/BinaryFormat/ELF.h
+++ b/llvm/include/llvm/BinaryFormat/ELF.h
@@ -917,6 +917,7 @@ enum : unsigned {
   EF_SBF_V1 = 0x01,
   EF_SBF_V2 = 0x02,
   EF_SBF_V3 = 0x03,
+  EF_SBF_V4 = 0x04,
 };
 
 // ELF Relocation types for SBF.

--- a/llvm/lib/Target/SBF/MCTargetDesc/SBFMCTargetDesc.cpp
+++ b/llvm/lib/Target/SBF/MCTargetDesc/SBFMCTargetDesc.cpp
@@ -76,6 +76,8 @@ static MCStreamer *createSBFMCStreamer(const Triple &T, MCContext &Ctx,
     EFlag = llvm::ELF::EF_SBF_V2;
   } else if (CPU == "v3") {
     EFlag = llvm::ELF::EF_SBF_V3;
+  } else if (CPU == "v4") {
+    EFlag = llvm::ELF::EF_SBF_V4;
   }
   S->getWriter().setELFHeaderEFlags(EFlag);
 

--- a/llvm/lib/Target/SBF/SBFSubtarget.cpp
+++ b/llvm/lib/Target/SBF/SBFSubtarget.cpp
@@ -43,7 +43,7 @@ void SBFSubtarget::initializeEnvironment(const Triple &TT) {
   assert(TT.getArch() == Triple::sbf && "expected Triple::sbf");
   UseDwarfRIS = false;
 
-  // SBFv2 features
+  // New SBF features
   HasJmpExt = false;
   HasDynamicFrames = false;
   DisableNeg = false;
@@ -56,6 +56,7 @@ void SBFSubtarget::initializeEnvironment(const Triple &TT) {
   HasExplicitSignExt = false;
   NewMemEncoding = false;
   HasStaticSyscalls = false;
+  IsAbiV2 = false;
 }
 
 void SBFSubtarget::initSubtargetFeatures(StringRef CPU, StringRef FS) {

--- a/llvm/lib/Target/SBF/SBFSubtarget.h
+++ b/llvm/lib/Target/SBF/SBFSubtarget.h
@@ -88,6 +88,9 @@ protected:
   // Whether we enable the new encoding for memory instructions
   bool NewMemEncoding;
 
+  // Whether we are using AbiV2
+  bool IsAbiV2;
+
   std::unique_ptr<CallLowering> CallLoweringInfo;
   std::unique_ptr<InstructionSelector> InstSelector;
   std::unique_ptr<LegalizerInfo> Legalizer;

--- a/llvm/lib/Target/SBF/SBFTargetFeatures.td
+++ b/llvm/lib/Target/SBF/SBFTargetFeatures.td
@@ -52,15 +52,26 @@ def FeatureNewMemEncoding : SubtargetFeature<"mem-encoding", "NewMemEncoding",
 def FeatureJumpExt : SubtargetFeature<"jmp-ext", "HasJmpExt",
                                        "true", "Enable jumps with less than and less than or equal">;
 
+def FeatureAbiV2 : SubtargetFeature<"abi-v2", "IsAbiV2",
+                                       "true", "Enables AbiV2 in SBF (no-op in LLVM)">;
+
+
 class Proc<string Name, list<SubtargetFeature> Features>
  : Processor<Name, NoItineraries, Features>;
 
 def : Proc<"generic", []>;
 
 def : Proc<"v1", [FeatureDynamicFrames, FeatureStoreImm, FeatureJumpExt]>;
+
 def : Proc<"v2", [FeatureDynamicFrames, FeatureStoreImm, FeatureJumpExt, FeatureDisableLddw,
                   FeatureNewMemEncoding, FeatureCallxRegSrc, FeaturePqrInstr, FeatureExplicitSext,
                   FeatureDisableNeg, FeatureReverseSubImm, ALU32]>;
+
 def : Proc<"v3", [FeatureDynamicFrames, FeatureStoreImm, FeatureJumpExt, FeatureDisableLddw,
                   FeatureNewMemEncoding, FeatureCallxRegSrc, FeaturePqrInstr, FeatureExplicitSext,
                   FeatureDisableNeg, FeatureReverseSubImm, ALU32, FeatureStaticSyscalls, FeatureRelocAbs64]>;
+
+def : Proc<"v4", [FeatureDynamicFrames, FeatureStoreImm, FeatureJumpExt, FeatureDisableLddw,
+                  FeatureNewMemEncoding, FeatureCallxRegSrc, FeaturePqrInstr, FeatureExplicitSext,
+                  FeatureDisableNeg, FeatureReverseSubImm, ALU32, FeatureStaticSyscalls, FeatureRelocAbs64,
+                  FeatureAbiV2]>;

--- a/llvm/test/MC/SBF/elf-flags.s
+++ b/llvm/test/MC/SBF/elf-flags.s
@@ -22,7 +22,9 @@
 # RUN: llvm-mc -triple=sbpfv3-solana-solana -filetype=obj < %s \
 # RUN:   | llvm-readobj --file-headers - \
 # RUN:   | FileCheck -check-prefix=CHECK-SBFV3 %s
-
+# RUN: llvm-mc -triple=sbf-solana-solana -mcpu=v4 -filetype=obj < %s \
+# RUN:   | llvm-readobj --file-headers - \
+# RUN:   | FileCheck -check-prefix=CHECK-SBFV4 %s
 
 # CHECK-NONE:       Flags [ (0x0)
 # CHECK-NONE-NEXT:  ]
@@ -39,5 +41,9 @@
 # CHECK-SBFV3-NEXT:    0x1
 # CHECK-SBFV3-NEXT:    0x2
 # CHECK-SBFV3-NEXT:  ]
+
+# CHECK-SBFV4:       Flags [ (0x4)
+# CHECK-SBFV4-NEXT:    0x4
+# CHECK-SBFV4-NEXT:  ]
 
 mov64 r0, r0

--- a/llvm/tools/llvm-objdump/llvm-objdump.cpp
+++ b/llvm/tools/llvm-objdump/llvm-objdump.cpp
@@ -2597,6 +2597,9 @@ static void disassembleObject(ObjectFile *Obj, bool InlineRelocs) {
       case llvm::ELF::EF_SBF_V3:
         MCPU = "v3";
         break;
+      case llvm::ELF::EF_SBF_V4:
+        MCPU = "v4";
+        break;
       default:
         MCPU = "generic";
         break;


### PR DESCRIPTION
This PR creates the v4 CPU type for the SBF target. It includes a `abi-v2` target feature to be surfaced to Rust as a specific target feature for conditional compilation.

A follow-up PR will create the `sbpfv4-solana-solana` target triple.