### PR TITLE
[SOL] Create sbpfv0 and sbpfv4 targets

### DIFF
--- a/llvm/include/llvm/TargetParser/Triple.h
+++ b/llvm/include/llvm/TargetParser/Triple.h
@@ -180,9 +180,11 @@ public:
     DXILSubArch_v1_8,
     LatestDXILSubArch = DXILSubArch_v1_8,
 
+    SBFSubArch_v0,
     SBFSubArch_v1,
     SBFSubArch_v2,
     SBFSubArch_v3,
+    SBFSubArch_v4,
   };
   enum VendorType {
     UnknownVendor,

--- a/llvm/lib/Target/SBF/TargetInfo/SBFTargetInfo.cpp
+++ b/llvm/lib/Target/SBF/TargetInfo/SBFTargetInfo.cpp
@@ -19,6 +19,9 @@ Target &llvm::getTheSBFXTarget() {
 std::string llvm::cpuFromSubArch(const Triple &TT, const std::string &CPU) {
   std::string CpuType;
   switch (TT.getSubArch()) {
+  case Triple::SBFSubArch_v0:
+    CpuType = "generic";
+    break;
   case Triple::SBFSubArch_v1:
     CpuType = "v1";
     break;
@@ -27,6 +30,9 @@ std::string llvm::cpuFromSubArch(const Triple &TT, const std::string &CPU) {
     break;
   case Triple::SBFSubArch_v3:
     CpuType = "v3";
+    break;
+  case Triple::SBFSubArch_v4:
+    CpuType = "v4";
     break;
   default:
     break;

--- a/llvm/lib/TargetParser/Triple.cpp
+++ b/llvm/lib/TargetParser/Triple.cpp
@@ -391,8 +391,9 @@ static Triple::ArchType parseBPFArch(StringRef ArchName) {
   } else if (ArchName == "bpf_le" || ArchName == "bpfel") {
     return Triple::bpfel;
   } else if (ArchName == "sbf" || ArchName == "sbpf" ||
-             ArchName == "sbpfv1" || ArchName == "sbpfv2" ||
-             ArchName == "sbpfv3") {
+             ArchName == "sbpfv0" || ArchName == "sbpfv1" ||
+             ArchName == "sbpfv2" || ArchName == "sbpfv3" ||
+             ArchName == "sbpfv4") {
     return Triple::sbf;
   } else {
     return Triple::UnknownArch;
@@ -806,9 +807,11 @@ static Triple::SubArchType parseSubArch(StringRef SubArchName) {
 
   if (SubArchName.starts_with("sbpf")) {
     return StringSwitch<Triple::SubArchType>(SubArchName)
+        .EndsWith("v0", Triple::SBFSubArch_v0)
         .EndsWith("v1", Triple::SBFSubArch_v1)
         .EndsWith("v2", Triple::SBFSubArch_v2)
         .EndsWith("v3", Triple::SBFSubArch_v3)
+        .EndsWith("v4", Triple::SBFSubArch_v4)
         .Default(Triple::NoSubArch);
   }
 

--- a/llvm/test/CodeGen/SBF/ninline_asm.ll
+++ b/llvm/test/CodeGen/SBF/ninline_asm.ll
@@ -1,4 +1,6 @@
 ; RUN: llc < %s -march=sbf -verify-machineinstrs | FileCheck %s
+; RUN: llc < %s -mtriple=sbpf-solana-solana -verify-machineinstrs | FileCheck %s
+; RUN: llc < %s -mtriple=sbpfv0-solana-solana -verify-machineinstrs | FileCheck %s
 
 @g = common global [2 x i32] zeroinitializer, align 4
 

--- a/llvm/test/MC/SBF/elf-flags.s
+++ b/llvm/test/MC/SBF/elf-flags.s
@@ -4,6 +4,9 @@
 # RUN: llvm-mc -triple=sbpf-solana-solana -filetype=obj < %s \
 # RUN:   | llvm-readobj --file-headers - \
 # RUN:   | FileCheck -check-prefix=CHECK-NONE %s
+# RUN: llvm-mc -triple=sbpfv0-solana-solana -filetype=obj < %s \
+# RUN:   | llvm-readobj --file-headers - \
+# RUN:   | FileCheck -check-prefix=CHECK-NONE %s
 # RUN: llvm-mc -triple=sbf-solana-solana -mcpu=v1 -filetype=obj < %s \
 # RUN:   | llvm-readobj --file-headers - \
 # RUN:   | FileCheck -check-prefix=CHECK-SBFV1 %s
@@ -23,6 +26,9 @@
 # RUN:   | llvm-readobj --file-headers - \
 # RUN:   | FileCheck -check-prefix=CHECK-SBFV3 %s
 # RUN: llvm-mc -triple=sbf-solana-solana -mcpu=v4 -filetype=obj < %s \
+# RUN:   | llvm-readobj --file-headers - \
+# RUN:   | FileCheck -check-prefix=CHECK-SBFV4 %s
+# RUN: llvm-mc -triple=sbpfv4-solana-solana -filetype=obj < %s \
 # RUN:   | llvm-readobj --file-headers - \
 # RUN:   | FileCheck -check-prefix=CHECK-SBFV4 %s
 

--- a/llvm/unittests/TargetParser/TripleTest.cpp
+++ b/llvm/unittests/TargetParser/TripleTest.cpp
@@ -738,6 +738,13 @@ TEST(TripleTest, ParsedIDs) {
   EXPECT_EQ(Triple::SolanaOS, T.getOS());
   EXPECT_EQ(Triple::UnknownEnvironment, T.getEnvironment());
 
+  T = Triple("sbpfv0-solana-solana");
+  EXPECT_EQ(Triple::sbf, T.getArch());
+  EXPECT_EQ(Triple::SBFSubArch_v0, T.getSubArch());
+  EXPECT_EQ(Triple::Solana, T.getVendor());
+  EXPECT_EQ(Triple::SolanaOS, T.getOS());
+  EXPECT_EQ(Triple::UnknownEnvironment, T.getEnvironment());
+
   T = Triple("sbpfv1-solana-solana");
   EXPECT_EQ(Triple::sbf, T.getArch());
   EXPECT_EQ(Triple::SBFSubArch_v1, T.getSubArch());
@@ -755,6 +762,13 @@ TEST(TripleTest, ParsedIDs) {
   T = Triple("sbpfv3-solana-solana");
   EXPECT_EQ(Triple::sbf, T.getArch());
   EXPECT_EQ(Triple::SBFSubArch_v3, T.getSubArch());
+  EXPECT_EQ(Triple::Solana, T.getVendor());
+  EXPECT_EQ(Triple::SolanaOS, T.getOS());
+  EXPECT_EQ(Triple::UnknownEnvironment, T.getEnvironment());
+
+  T = Triple("sbpfv4-solana-solana");
+  EXPECT_EQ(Triple::sbf, T.getArch());
+  EXPECT_EQ(Triple::SBFSubArch_v4, T.getSubArch());
   EXPECT_EQ(Triple::Solana, T.getVendor());
   EXPECT_EQ(Triple::SolanaOS, T.getOS());
   EXPECT_EQ(Triple::UnknownEnvironment, T.getEnvironment());


### PR DESCRIPTION
This PR creates the target triples `sbpfv0-solana-solana` and `sbpfv4-solana-solana` to be used in the Rust compiler.