### PR TITLE
[SOL] Add missing space in error message about stack usage

### DIFF
--- a/llvm/lib/Target/SBF/SBFRegisterInfo.cpp
+++ b/llvm/lib/Target/SBF/SBFRegisterInfo.cpp
@@ -158,7 +158,7 @@ int SBFRegisterInfo::resolveInternalFrameIndex(
       dbgs() << "Error: A function call in method "
              << MF.getFunction().getName()
              << " overwrites values in the frame. Please, decrease stack usage "
-             << "or remove parameters from the call."
+             << "or remove parameters from the call. "
              << "The function call may cause undefined behavior "
                 "during execution.\n\n";
     }


### PR DESCRIPTION
The compiler sometimes reports:

    Error: A function call in method [...] overwrites values in the
    frame. Please, decrease stack usage or remove parameters from the
    call.The function call may cause undefined behavior during execution.

Add a missing space between "call." and "The function".

Fixes: https://github.com/anza-xyz/llvm-project/issues/146

For information, I checked that the code-gen tests still pass, including https://github.com/anza-xyz/llvm-project/blob/8a86d2abef8f815f1dec93662605e0082c7d7237/llvm/test/CodeGen/SBF/func_call_error.ll (which generates the error message). I used these commands to test my LLVM build:

```sh
cmake -S llvm -B build -G Ninja -DCMAKE_BUILD_TYPE=Release -DLLVM_TARGETS_TO_BUILD=SBF
ninja -C build check-llvm
./build/bin/llvm-lit -v llvm/test/CodeGen/SBF/func_call_error.ll
``` 