### PR TITLE
[SOL] Always add return for SBPFv3

### DIFF
--- a/llvm/lib/Target/SBF/SBF.h
+++ b/llvm/lib/Target/SBF/SBF.h
@@ -28,7 +28,8 @@ FunctionPass *createSBFISelDag(SBFTargetMachine &TM);
 FunctionPass *createSBFMISimplifyPatchablePass();
 FunctionPass *createSBFMIPeepholePass();
 FunctionPass *createSBFMIPeepholeTruncElimPass();
-FunctionPass *createSBFMIPreEmitPeepholePass();
+FunctionPass *createSBFMIPreEmitPeepholePass(CodeGenOptLevel OptLevel,
+                                             bool DisablePeephole);
 FunctionPass *createSBFMIPreEmitCheckingPass();
 
 InstructionSelector *createSBFInstructionSelector(const SBFTargetMachine &,

--- a/llvm/lib/Target/SBF/SBFMIPeephole.cpp
+++ b/llvm/lib/Target/SBF/SBFMIPeephole.cpp
@@ -200,10 +200,7 @@ bool SBFMIPreEmitPeephole::addReturn() {
 
     MachineInstr &MI = MBB.back();
     unsigned Opcode = MI.getOpcode();
-    if (Opcode == SBF::JAL ||
-        Opcode == SBF::JALX ||
-        Opcode == SBF::JALX_v2 ||
-        Opcode == SBF::SYSCALL_v3) {
+    if (Opcode != SBF::RETURN_v3) {
       BuildMI(&MBB, MI.getDebugLoc(), TII->get(SBF::RETURN_v3));
       Added = true;
     }

--- a/llvm/lib/Target/SBF/SBFMIPeephole.cpp
+++ b/llvm/lib/Target/SBF/SBFMIPeephole.cpp
@@ -131,8 +131,12 @@ struct SBFMIPreEmitPeephole : public MachineFunctionPass {
   const TargetRegisterInfo *TRI;
   const SBFInstrInfo *TII;
   const SBFSubtarget *SubTarget;
+  const CodeGenOptLevel OptLevel;
+  const bool DisablePeephole;
 
-  SBFMIPreEmitPeephole() : MachineFunctionPass(ID) {
+  SBFMIPreEmitPeephole(CodeGenOptLevel OptLevel, bool DisablePeephole)
+      : MachineFunctionPass(ID), OptLevel(OptLevel),
+        DisablePeephole(DisablePeephole) {
     initializeSBFMIPreEmitPeepholePass(*PassRegistry::getPassRegistry());
   }
 
@@ -147,14 +151,16 @@ public:
 
   // Main entry point for this pass.
   bool runOnMachineFunction(MachineFunction &MF) override {
-    if (skipFunction(MF.getFunction()))
-      return false;
-
     initialize(MF);
 
     bool PeepholeExecuted = false;
     if (SubTarget->getHasStaticSyscalls())
       PeepholeExecuted |= addReturn();
+
+    // We shall not skip adding the return to SBPFv3 functions
+    if (skipFunction(MF.getFunction()) || OptLevel == CodeGenOptLevel::None ||
+        DisablePeephole)
+      return PeepholeExecuted;
 
     PeepholeExecuted |= eliminateRedundantMov();
 
@@ -250,9 +256,9 @@ INITIALIZE_PASS(SBFMIPreEmitPeephole, "sbf-mi-pemit-peephole",
                 "SBF PreEmit Peephole Optimization", false, false)
 
 char SBFMIPreEmitPeephole::ID = 0;
-FunctionPass* llvm::createSBFMIPreEmitPeepholePass()
+FunctionPass* llvm::createSBFMIPreEmitPeepholePass(CodeGenOptLevel OptLevel, bool DisablePeephole)
 {
-  return new SBFMIPreEmitPeephole();
+  return new SBFMIPreEmitPeephole(OptLevel, DisablePeephole);
 }
 
 STATISTIC(TruncElemNum, "Number of truncation eliminated");

--- a/llvm/lib/Target/SBF/SBFTargetMachine.cpp
+++ b/llvm/lib/Target/SBF/SBFTargetMachine.cpp
@@ -168,7 +168,5 @@ void SBFPassConfig::addMachineSSAOptimization() {
 
 void SBFPassConfig::addPreEmitPass() {
   addPass(createSBFMIPreEmitCheckingPass());
-  if (getOptLevel() != CodeGenOptLevel::None)
-    if (!DisableMIPeephole)
-      addPass(createSBFMIPreEmitPeepholePass());
+  addPass(createSBFMIPreEmitPeepholePass(getOptLevel(), DisableMIPeephole));
 }

--- a/llvm/test/CodeGen/SBF/unreachable_return.ll
+++ b/llvm/test/CodeGen/SBF/unreachable_return.ll
@@ -1,4 +1,5 @@
 ; RUN: llc -O2 -march=sbf -mcpu=v3 < %s | FileCheck %s
+; RUN: llc -O0 -march=sbf -mcpu=v3 < %s | FileCheck %s
 
 declare void @dummy_func(i8, ptr, ptr, ptr, ptr, ptr, ptr)
 


### PR DESCRIPTION
Since we are doing a new release of platform tools, I was fixing the CI for compiler-builtins. I found that I was not inserting the return for unreachable branches when using `-O0`. This PR fixes that.