### PR TITLE
[SOL] Allow branch folding to run in SBF

### DIFF
--- a/llvm/lib/Target/SBF/SBFInstrInfo.cpp
+++ b/llvm/lib/Target/SBF/SBFInstrInfo.cpp
@@ -18,12 +18,49 @@
 #include "llvm/IR/DebugLoc.h"
 #include "llvm/Support/ErrorHandling.h"
 #include <cassert>
-#include <iterator>
 
 #define GET_INSTRINFO_CTOR_DTOR
 #include "SBFGenInstrInfo.inc"
 
 using namespace llvm;
+
+static inline bool isUncondBranchOpcode(int Opc) { return Opc == SBF::JMP; }
+
+static inline bool isCondBranchOpcode(int Opc) {
+  switch (Opc) {
+  case SBF::JEQ_ri:
+  case SBF::JEQ_rr:
+  case SBF::JUGT_ri:
+  case SBF::JUGT_rr:
+  case SBF::JUGE_ri:
+  case SBF::JUGE_rr:
+  case SBF::JNE_ri:
+  case SBF::JNE_rr:
+  case SBF::JSGT_ri:
+  case SBF::JSGT_rr:
+  case SBF::JSGE_ri:
+  case SBF::JSGE_rr:
+  case SBF::JULT_ri:
+  case SBF::JULT_rr:
+  case SBF::JULE_ri:
+  case SBF::JULE_rr:
+  case SBF::JSLT_ri:
+  case SBF::JSLT_rr:
+  case SBF::JSLE_ri:
+  case SBF::JSLE_rr:
+    return true;
+  default:
+    return false;
+  }
+}
+
+static void parseCondBranch(MachineInstr *LastInst, MachineBasicBlock *&Target,
+                            SmallVectorImpl<MachineOperand> &Cond) {
+  Cond.push_back(MachineOperand::CreateImm(LastInst->getOpcode()));
+  Cond.push_back(LastInst->getOperand(0));
+  Cond.push_back(LastInst->getOperand(1));
+  Target = LastInst->getOperand(2).getMBB();
+}
 
 SBFInstrInfo::SBFInstrInfo()
     : SBFGenInstrInfo(SBF::ADJCALLSTACKDOWN, SBF::ADJCALLSTACKUP) {}
@@ -104,65 +141,114 @@ bool SBFInstrInfo::analyzeBranch(MachineBasicBlock &MBB,
                                  MachineBasicBlock *&FBB,
                                  SmallVectorImpl<MachineOperand> &Cond,
                                  bool AllowModify) const {
-  // Start from the bottom of the block and work up, examining the
-  // terminator instructions.
-  MachineBasicBlock::iterator I = MBB.end();
-  while (I != MBB.begin()) {
-    --I;
-    if (I->isDebugInstr())
-      continue;
+  // If the block has no terminators, it just falls into the block after it.
+  MachineBasicBlock::iterator I = MBB.getLastNonDebugInstr();
+  if (I == MBB.end())
+    return false;
 
-    // Working from the bottom, when we see a non-terminator
-    // instruction, we're done.
-    if (!isUnpredicatedTerminator(*I))
-      break;
+  if (!isUnpredicatedTerminator(*I))
+    return false;
 
-    // A terminator that isn't a branch can't easily be handled
-    // by this analysis.
-    if (!I->isBranch())
-      return true;
+  // Get the last instruction in the block.
+  MachineInstr *LastInst = &*I;
 
-    // Handle unconditional branches.
-    if (I->getOpcode() == SBF::JMP) {
-      if (!AllowModify) {
-        TBB = I->getOperand(0).getMBB();
-        continue;
-      }
-
-      // If the block has any instructions after a J, delete them.
-      MBB.erase(std::next(I), MBB.end());
-      Cond.clear();
-      FBB = nullptr;
-
-      // Delete the J if it's equivalent to a fall-through.
-      if (MBB.isLayoutSuccessor(I->getOperand(0).getMBB())) {
-        TBB = nullptr;
-        I->eraseFromParent();
-        I = MBB.end();
-        continue;
-      }
-
-      // TBB is used to indicate the unconditinal destination.
-      TBB = I->getOperand(0).getMBB();
-      continue;
+  // If there is only one terminator instruction, process it.
+  unsigned LastOpc = LastInst->getOpcode();
+  if (I == MBB.begin() || !isUnpredicatedTerminator(*--I)) {
+    if (isUncondBranchOpcode(LastOpc)) {
+      TBB = LastInst->getOperand(0).getMBB();
+      return false;
     }
-    // Cannot handle conditional branches
-    return true;
+    if (isCondBranchOpcode(LastOpc)) {
+      // Block ends with fall-through condbranch.
+      parseCondBranch(LastInst, TBB, Cond);
+      return false;
+    }
+    return true; // Unknown case
   }
 
-  return false;
+  // Get the instruction before it if it is a terminator.
+  MachineInstr *SecondLastInst = &*I;
+  unsigned SecondLastOpc = SecondLastInst->getOpcode();
+
+  // If AllowModify is true and the block ends with two or more unconditional
+  // branches, delete all but the first unconditional branch.
+  if (AllowModify && isUncondBranchOpcode(LastOpc)) {
+    while (isUncondBranchOpcode(SecondLastOpc)) {
+      LastInst->eraseFromParent();
+      LastInst = SecondLastInst;
+      LastOpc = LastInst->getOpcode();
+      if (I == MBB.begin() || !isUnpredicatedTerminator(*--I)) {
+        // Return now the only terminator is an unconditional branch.
+        TBB = LastInst->getOperand(0).getMBB();
+        return false;
+      }
+      SecondLastInst = &*I;
+      SecondLastOpc = SecondLastInst->getOpcode();
+    }
+  }
+
+  // If we're allowed to modify and the block ends in a unconditional branch
+  // which could simply fallthrough, remove the branch.  (Note: This case only
+  // matters when we can't understand the whole sequence, otherwise it's also
+  // handled by BranchFolding.cpp.)
+  if (AllowModify && isUncondBranchOpcode(LastOpc) &&
+      MBB.isLayoutSuccessor(getBranchDestBlock(*LastInst))) {
+    LastInst->eraseFromParent();
+    LastInst = SecondLastInst;
+    LastOpc = LastInst->getOpcode();
+    if (I == MBB.begin() || !isUnpredicatedTerminator(*--I)) {
+      assert(!isUncondBranchOpcode(LastOpc) &&
+             "unreachable unconditional branches removed above");
+
+      if (isCondBranchOpcode(LastOpc)) {
+        // Block ends with fall-through condbranch.
+        parseCondBranch(LastInst, TBB, Cond);
+        return false;
+      }
+      return true; // Can't handle indirect branch.
+    }
+    SecondLastInst = &*I;
+    SecondLastOpc = SecondLastInst->getOpcode();
+  }
+
+  // If there are three terminators, we don't know what sort of block this is.
+  if (SecondLastInst && I != MBB.begin() && isUnpredicatedTerminator(*--I))
+    return true;
+
+  // If the block ends with a conditional jump and a JA, handle it.
+  if (isCondBranchOpcode(SecondLastOpc) && isUncondBranchOpcode(LastOpc)) {
+    parseCondBranch(SecondLastInst, TBB, Cond);
+    FBB = LastInst->getOperand(0).getMBB();
+    return false;
+  }
+
+  // If the block ends with two unconditional branches, handle it.  The second
+  // one is not executed, so remove it.
+  if (isUncondBranchOpcode(SecondLastOpc) && isUncondBranchOpcode(LastOpc)) {
+    TBB = SecondLastInst->getOperand(0).getMBB();
+    I = LastInst;
+    if (AllowModify)
+      I->eraseFromParent();
+    return false;
+  }
+
+  // Otherwise, can't handle this.
+  return true;
 }
 
 unsigned SBFInstrInfo::insertBranch(MachineBasicBlock &MBB,
                                     MachineBasicBlock *TBB,
                                     MachineBasicBlock *FBB,
                                     ArrayRef<MachineOperand> Cond,
-                                    const DebugLoc &DL,
-                                    int *BytesAdded) const {
+                                    const DebugLoc &DL, int *BytesAdded) const {
   assert(!BytesAdded && "code size not handled");
 
   // Shouldn't be a fall through.
   assert(TBB && "insertBranch must not be told to insert a fallthrough");
+
+  if (BytesAdded)
+    *BytesAdded = 8;
 
   if (Cond.empty()) {
     // Unconditional branch
@@ -171,27 +257,139 @@ unsigned SBFInstrInfo::insertBranch(MachineBasicBlock &MBB,
     return 1;
   }
 
-  llvm_unreachable("Unexpected conditional branch");
+  // See the order we parse the jump information in `parseCondBranch`
+  BuildMI(&MBB, DL, get(Cond[0].getImm()))
+      .add(Cond[1])
+      .add(Cond[2])
+      .addMBB(TBB);
+
+  if (FBB) {
+    BuildMI(&MBB, DL, get(SBF::JMP)).addMBB(FBB);
+    if (BytesAdded)
+      *BytesAdded += 8;
+  }
+
+  return 1;
 }
 
 unsigned SBFInstrInfo::removeBranch(MachineBasicBlock &MBB,
                                     int *BytesRemoved) const {
   assert(!BytesRemoved && "code size not handled");
 
-  MachineBasicBlock::iterator I = MBB.end();
-  unsigned Count = 0;
+  MachineBasicBlock::iterator I = MBB.getLastNonDebugInstr();
+  if (I == MBB.end())
+    return 0;
 
-  while (I != MBB.begin()) {
-    --I;
-    if (I->isDebugInstr())
-      continue;
-    if (I->getOpcode() != SBF::JMP)
-      break;
-    // Remove the branch.
-    I->eraseFromParent();
-    I = MBB.end();
-    ++Count;
+  if (!isUncondBranchOpcode(I->getOpcode()) &&
+      !isCondBranchOpcode(I->getOpcode()))
+    return 0;
+
+  // Remove the branch.
+  I->eraseFromParent();
+
+  I = MBB.end();
+
+  if (I == MBB.begin()) {
+    if (BytesRemoved)
+      *BytesRemoved = 8;
+    return 1;
   }
 
-  return Count;
+  --I;
+  if (!isCondBranchOpcode(I->getOpcode())) {
+    if (BytesRemoved)
+      *BytesRemoved = 8;
+    return 1;
+  }
+
+  // Remove the branch.
+  I->eraseFromParent();
+  if (BytesRemoved)
+    *BytesRemoved = 16;
+
+  return 2;
+}
+
+bool SBFInstrInfo::reverseBranchCondition(
+    SmallVectorImpl<MachineOperand> &Cond) const {
+  switch (Cond[0].getImm()) {
+  default:
+    llvm_unreachable("Unknown conditional branch!");
+  case SBF::JEQ_ri:
+    Cond[0].setImm(SBF::JNE_ri);
+    break;
+  case SBF::JEQ_rr:
+    Cond[0].setImm(SBF::JNE_rr);
+    break;
+  case SBF::JUGT_ri:
+    Cond[0].setImm(SBF::JULE_ri);
+    break;
+  case SBF::JUGT_rr:
+    Cond[0].setImm(SBF::JULE_rr);
+    break;
+  case SBF::JUGE_ri:
+    Cond[0].setImm(SBF::JULT_ri);
+    break;
+  case SBF::JUGE_rr:
+    Cond[0].setImm(SBF::JULT_rr);
+    break;
+  case SBF::JNE_ri:
+    Cond[0].setImm(SBF::JEQ_ri);
+    break;
+  case SBF::JNE_rr:
+    Cond[0].setImm(SBF::JEQ_rr);
+    break;
+  case SBF::JSGT_ri:
+    Cond[0].setImm(SBF::JSLE_ri);
+    break;
+  case SBF::JSGT_rr:
+    Cond[0].setImm(SBF::JSLE_rr);
+    break;
+  case SBF::JSGE_ri:
+    Cond[0].setImm(SBF::JSLT_ri);
+    break;
+  case SBF::JSGE_rr:
+    Cond[0].setImm(SBF::JSLT_rr);
+    break;
+  case SBF::JULT_ri:
+    Cond[0].setImm(SBF::JUGE_ri);
+    break;
+  case SBF::JULT_rr:
+    Cond[0].setImm(SBF::JUGE_rr);
+    break;
+  case SBF::JULE_ri:
+    Cond[0].setImm(SBF::JUGT_ri);
+    break;
+  case SBF::JULE_rr:
+    Cond[0].setImm(SBF::JUGT_rr);
+    break;
+  case SBF::JSLT_ri:
+    Cond[0].setImm(SBF::JSGE_ri);
+    break;
+  case SBF::JSLT_rr:
+    Cond[0].setImm(SBF::JSGE_rr);
+    break;
+  case SBF::JSLE_ri:
+    Cond[0].setImm(SBF::JSGT_ri);
+    break;
+  case SBF::JSLE_rr:
+    Cond[0].setImm(SBF::JSGT_rr);
+    break;
+  }
+
+  return false;
+}
+
+MachineBasicBlock *
+SBFInstrInfo::getBranchDestBlock(const MachineInstr &MI) const {
+  unsigned Opcode = MI.getOpcode();
+  if (Opcode == SBF::JMP) {
+    return MI.getOperand(0).getMBB();
+  }
+
+  if (isCondBranchOpcode(Opcode)) {
+    return MI.getOperand(2).getMBB();
+  }
+
+  llvm_unreachable("unexpected opcode!");
 }

--- a/llvm/lib/Target/SBF/SBFInstrInfo.cpp
+++ b/llvm/lib/Target/SBF/SBFInstrInfo.cpp
@@ -393,3 +393,10 @@ SBFInstrInfo::getBranchDestBlock(const MachineInstr &MI) const {
 
   llvm_unreachable("unexpected opcode!");
 }
+
+unsigned SBFInstrInfo::getInstSizeInBytes(const MachineInstr &MI) const {
+  if (MI.getOpcode() == SBF::LD_imm64)
+    return 16;
+
+  return 8;
+}

--- a/llvm/lib/Target/SBF/SBFInstrInfo.h
+++ b/llvm/lib/Target/SBF/SBFInstrInfo.h
@@ -58,6 +58,11 @@ public:
                         int *BytesAdded = nullptr) const override;
   void initializeTargetFeatures(bool HasExplicitSext, bool NewMemEncoding);
 
+  bool
+  reverseBranchCondition(SmallVectorImpl<MachineOperand> &Cond) const override;
+
+  MachineBasicBlock *getBranchDestBlock(const MachineInstr &MI) const override;
+
 private:
   bool HasExplicitSignExt;
   bool NewMemEncoding;

--- a/llvm/lib/Target/SBF/SBFInstrInfo.h
+++ b/llvm/lib/Target/SBF/SBFInstrInfo.h
@@ -63,6 +63,8 @@ public:
 
   MachineBasicBlock *getBranchDestBlock(const MachineInstr &MI) const override;
 
+  unsigned getInstSizeInBytes(const MachineInstr &MI) const override;
+
 private:
   bool HasExplicitSignExt;
   bool NewMemEncoding;

--- a/llvm/test/CodeGen/SBF/branch_fold.ll
+++ b/llvm/test/CodeGen/SBF/branch_fold.ll
@@ -1,0 +1,82 @@
+; RUN: llc -march=sbf -O3 < %s | FileCheck %s
+
+; ModuleID = 'pinocchio.2fd090a2518ac939-cgu.0'
+source_filename = "pinocchio.2fd090a2518ac939-cgu.0"
+target datalayout = "e-m:e-p:64:64-i64:64-n32:64-S128"
+target triple = "sbf"
+
+
+; Function Attrs: nofree noinline norecurse nosync nounwind memory(readwrite, inaccessiblemem: none)
+define void @deserialize(ptr dead_on_unwind noalias nocapture noundef writable writeonly sret([24 x i8]) align 8 dereferenceable(24) %_0, ptr noundef %0, ptr noundef %1) unnamed_addr {
+start:
+  %_4 = load i64, ptr %0, align 8
+  %_7 = getelementptr inbounds i8, ptr %0, i64 8
+  %_9.not = icmp eq i64 %_4, 0
+  br i1 %_9.not, label %bb8, label %bb1
+
+bb1:                                              ; preds = %start
+  store ptr %_7, ptr %1, align 8
+  %_16 = getelementptr inbounds i8, ptr %0, i64 10344
+  %2 = getelementptr inbounds i8, ptr %0, i64 88
+  %_21 = load i64, ptr %2, align 8
+  %_18 = getelementptr inbounds i8, ptr %_16, i64 %_21
+  %_24 = ptrtoint ptr %_18 to i64
+  %_23 = add i64 %_24, 7
+  %_22 = and i64 %_23, -8
+  %3 = inttoptr i64 %_22 to ptr
+  %to_process.sroa.0.05 = add i64 %_4, -1
+  %_26.not6 = icmp eq i64 %to_process.sroa.0.05, 0
+  br i1 %_26.not6, label %bb8, label %bb3
+
+bb8:                                              ; preds = %bb2.backedge, %bb1, %start
+  %input.sroa.0.0 = phi ptr [ %_7, %start ], [ %3, %bb1 ], [ %input.sroa.0.1.be, %bb2.backedge ]
+  %_55 = load i64, ptr %input.sroa.0.0, align 8
+  %_58 = getelementptr inbounds i8, ptr %input.sroa.0.0, i64 8
+  %_65 = getelementptr inbounds i8, ptr %_58, i64 %_55
+  store ptr %_65, ptr %_0, align 8
+  %4 = getelementptr inbounds i8, ptr %_0, i64 8
+  store ptr %_58, ptr %4, align 8
+  %5 = getelementptr inbounds i8, ptr %_0, i64 16
+  store i64 %_55, ptr %5, align 8
+  ret void
+
+; CHECK: LBB0_4:
+; CHECK-NOT: jeq r4, 0, LBB0_7
+; CHECK-NOT: ja LBB0_3
+; CHECK: jne r4, 0, LBB0_4
+
+bb3:                                              ; preds = %bb1, %bb2.backedge
+  %to_process.sroa.0.09 = phi i64 [ %to_process.sroa.0.0, %bb2.backedge ], [ %to_process.sroa.0.05, %bb1 ]
+  %input.sroa.0.18 = phi ptr [ %input.sroa.0.1.be, %bb2.backedge ], [ %3, %bb1 ]
+  %accounts.sroa.0.07 = phi ptr [ %_28, %bb2.backedge ], [ %1, %bb1 ]
+  %_28 = getelementptr inbounds i8, ptr %accounts.sroa.0.07, i64 8
+  %_35 = load i8, ptr %input.sroa.0.18, align 8
+  %_34.not = icmp eq i8 %_35, -1
+  br i1 %_34.not, label %bb5, label %bb4
+
+bb5:                                              ; preds = %bb3
+  store ptr %input.sroa.0.18, ptr %_28, align 8
+  %_44 = getelementptr inbounds i8, ptr %input.sroa.0.18, i64 10336
+  %6 = getelementptr inbounds i8, ptr %input.sroa.0.18, i64 80
+  %_49 = load i64, ptr %6, align 8
+  %_46 = getelementptr inbounds i8, ptr %_44, i64 %_49
+  %_52 = ptrtoint ptr %_46 to i64
+  %_51 = add i64 %_52, 7
+  %_50 = and i64 %_51, -8
+  %7 = inttoptr i64 %_50 to ptr
+  br label %bb2.backedge
+
+bb2.backedge:                                     ; preds = %bb5, %bb4
+  %input.sroa.0.1.be = phi ptr [ %_32, %bb4 ], [ %7, %bb5 ]
+  %to_process.sroa.0.0 = add i64 %to_process.sroa.0.09, -1
+  %_26.not = icmp eq i64 %to_process.sroa.0.0, 0
+  br i1 %_26.not, label %bb8, label %bb3
+
+bb4:                                              ; preds = %bb3
+  %_32 = getelementptr inbounds i8, ptr %input.sroa.0.18, i64 8
+  %_40 = zext i8 %_35 to i64
+  %_39 = getelementptr inbounds ptr, ptr %1, i64 %_40
+  store ptr %_39, ptr %_28, align 8
+  br label %bb2.backedge
+}
+

--- a/llvm/test/CodeGen/SBF/cmp.ll
+++ b/llvm/test/CodeGen/SBF/cmp.ll
@@ -37,7 +37,7 @@ define signext i8 @foo_cmp2(i8 signext %a, i8 signext %b) #0 {
   %.0 = phi i8 [ %3, %2 ], [ %5, %4 ]
   ret i8 %.0
 ; CHECK-LABEL:foo_cmp2:
-; CHECK: jsgt r0, r1
+; CHECK: jsle r0, r1
 }
 
 ; Function Attrs: nounwind readnone uwtable
@@ -77,7 +77,7 @@ define signext i8 @foo_cmp4(i8 signext %a, i8 signext %b) #0 {
   %.0 = phi i8 [ %3, %2 ], [ %5, %4 ]
   ret i8 %.0
 ; CHECK-LABEL:foo_cmp4:
-; CHECK: jsgt r1, r0
+; CHECK: jsle r1, r0
 }
 
 ; Function Attrs: nounwind readnone uwtable

--- a/llvm/test/CodeGen/SBF/cttz-ctlz.ll
+++ b/llvm/test/CodeGen/SBF/cttz-ctlz.ll
@@ -27,12 +27,11 @@ define i32 @cttz_i32_zdef(i32 %a) {
 define i32 @cttz_i32(i32 %a) {
 ; CHECK-LABEL: cttz_i32:
 ; CHECK:       # %bb.0:
-; CHECK-NEXT:    mov64 r0, 32
 ; CHECK-NEXT:    mov64 r2, r1
 ; CHECK-NEXT:    lsh64 r2, 32
 ; CHECK-NEXT:    rsh64 r2, 32
-; CHECK-NEXT:    jeq r2, 0, LBB1_2
-; CHECK-NEXT:  # %bb.1: # %cond.false
+; CHECK-NEXT:    jeq r2, 0, LBB1_1
+; CHECK-NEXT:  # %bb.2: # %cond.false
 ; CHECK-NEXT:    mov64 r2, r1
 ; CHECK-NEXT:    neg64 r2
 ; CHECK-NEXT:    and64 r1, r2
@@ -43,7 +42,10 @@ define i32 @cttz_i32(i32 %a) {
 ; CHECK-NEXT:    lddw r2, {{\.?LCPI[0-9]+_[0-9]+}}
 ; CHECK-NEXT:    add64 r2, r1
 ; CHECK-NEXT:    ldxb r0, [r2 + 0]
-; CHECK-NEXT:  LBB1_2: # %cond.end
+; CHECK-NEXT:    ja LBB1_3
+; CHECK-NEXT:  LBB1_1:
+; CHECK-NEXT:    mov64 r0, 32
+; CHECK-NEXT:  LBB1_3: # %cond.end
 ; CHECK-NEXT:    exit
     %ret = call i32 @llvm.cttz.i32(i32 %a, i1 0)
     ret i32 %ret
@@ -72,9 +74,8 @@ define i64 @cttz_i64_zdef(i64 %a) {
 define i64 @cttz_i64(i64 %a) {
 ; CHECK-LABEL: cttz_i64:
 ; CHECK:       # %bb.0:
-; CHECK-NEXT:    mov64 r0, 64
-; CHECK-NEXT:    jeq r1, 0, LBB3_2
-; CHECK-NEXT:  # %bb.1: # %cond.false
+; CHECK-NEXT:    jeq r1, 0, LBB3_1
+; CHECK-NEXT:  # %bb.2: # %cond.false
 ; CHECK-NEXT:    mov64 r2, r1
 ; CHECK-NEXT:    neg64 r2
 ; CHECK-NEXT:    and64 r1, r2
@@ -84,7 +85,10 @@ define i64 @cttz_i64(i64 %a) {
 ; CHECK-NEXT:    lddw r2, {{\.?LCPI[0-9]+_[0-9]+}}
 ; CHECK-NEXT:    add64 r2, r1
 ; CHECK-NEXT:    ldxb r0, [r2 + 0]
-; CHECK-NEXT:  LBB3_2: # %cond.end
+; CHECK-NEXT:    ja LBB3_3
+; CHECK-NEXT:  LBB3_1:
+; CHECK-NEXT:    mov64 r0, 64
+; CHECK-NEXT:  LBB3_3: # %cond.end
 ; CHECK-NEXT:    exit
     %ret = call i64 @llvm.cttz.i64(i64 %a, i1 0)
     ret i64 %ret
@@ -148,12 +152,11 @@ define i32 @ctlz_i32_zdef(i32 %a) {
 define i32 @ctlz_i32(i32 %a) {
 ; CHECK-LABEL: ctlz_i32:
 ; CHECK:       # %bb.0:
-; CHECK-NEXT:    mov64 r0, 32
 ; CHECK-NEXT:    mov64 r2, r1
 ; CHECK-NEXT:    lsh64 r2, 32
 ; CHECK-NEXT:    rsh64 r2, 32
-; CHECK-NEXT:    jeq r2, 0, LBB5_2
-; CHECK-NEXT:  # %bb.1: # %cond.false
+; CHECK-NEXT:    jeq r2, 0, LBB5_1
+; CHECK-NEXT:  # %bb.2: # %cond.false
 ; CHECK-NEXT:    lddw r2, 4294967294
 ; CHECK-NEXT:    mov64 r3, r1
 ; CHECK-NEXT:    and64 r3, r2
@@ -197,7 +200,10 @@ define i32 @ctlz_i32(i32 %a) {
 ; CHECK-NEXT:    lddw r1, 4278190080
 ; CHECK-NEXT:    and64 r0, r1
 ; CHECK-NEXT:    rsh64 r0, 24
-; CHECK-NEXT:  LBB5_2: # %cond.end
+; CHECK-NEXT:    ja LBB5_3
+; CHECK-NEXT:  LBB5_1:
+; CHECK-NEXT:    mov64 r0, 32
+; CHECK-NEXT:  LBB5_3: # %cond.end
 ; CHECK-NEXT:    exit
     %ret = call i32 @llvm.ctlz.i32(i32 %a, i1 0)
     ret i32 %ret
@@ -255,9 +261,8 @@ define i64 @ctlz_i64_zdef(i64 %a) {
 define i64 @ctlz_i64(i64 %a) {
 ; CHECK-LABEL: ctlz_i64:
 ; CHECK:       # %bb.0:
-; CHECK-NEXT:    mov64 r0, 64
-; CHECK-NEXT:    jeq r1, 0, LBB7_2
-; CHECK-NEXT:  # %bb.1: # %cond.false
+; CHECK-NEXT:    jeq r1, 0, LBB7_1
+; CHECK-NEXT:  # %bb.2: # %cond.false
 ; CHECK-NEXT:    mov64 r2, r1
 ; CHECK-NEXT:    rsh64 r2, 1
 ; CHECK-NEXT:    or64 r1, r2
@@ -296,7 +301,10 @@ define i64 @ctlz_i64(i64 %a) {
 ; CHECK-NEXT:    lddw r1, 72340172838076673
 ; CHECK-NEXT:    mul64 r0, r1
 ; CHECK-NEXT:    rsh64 r0, 56
-; CHECK-NEXT:  LBB7_2: # %cond.end
+; CHECK-NEXT:    ja LBB7_3
+; CHECK-NEXT:  LBB7_1:
+; CHECK-NEXT:    mov64 r0, 64
+; CHECK-NEXT:  LBB7_3: # %cond.end
 ; CHECK-NEXT:    exit
     %ret = call i64 @llvm.ctlz.i64(i64 %a, i1 0)
     ret i64 %ret

--- a/llvm/test/CodeGen/SBF/remove_truncate_2.ll
+++ b/llvm/test/CodeGen/SBF/remove_truncate_2.ll
@@ -44,15 +44,15 @@ if.end:                                           ; preds = %entry
   %cmp4 = icmp eq i8 %2, 1
 ; CHECK:  mov64 r0, 3
 ; CHECK-NOT:  and64 r1, 255
-; CHECK:  jeq r1, 1,
+; CHECK:  jne r1, 1,
   br i1 %cmp4, label %cleanup, label %if.end13
 
 if.else:                                          ; preds = %entry
   %cmp9 = icmp eq i8 %2, 0
-; CHECK:  mov64 r0, 2
 ; CHECK-NOT:  and64 r1, 255
 ; CHECK:  jeq r1, 0,
   br i1 %cmp9, label %cleanup, label %if.end13
+; CHECK:  mov64 r0, 2
 
 if.end13:                                         ; preds = %if.else, %if.end
   br label %cleanup

--- a/llvm/test/CodeGen/SBF/select_ri.ll
+++ b/llvm/test/CodeGen/SBF/select_ri.ll
@@ -57,7 +57,7 @@ define i32 @test2() local_unnamed_addr #0 {
 entry:
   %0 = load i32, i32* @m, align 4
   %cmp = icmp slt i32 %0, 6
-; CHECK:  {{jslt|jsgt}} r{{[0-9]+}}, 6,
+; CHECK:  {{jsle|jsge}} r{{[0-9]+}}, 6,
   %1 = load i32, i32* @n, align 4
   %spec.select = select i1 %cmp, i32 %1, i32 %0
   ret i32 %spec.select


### PR DESCRIPTION
**Problem**

The SBF codegen has been generating awkward code for branches, particularly doing:
```
jeq r2, 0, LBB0_7
ja LBB0_3
```

While it could be doing:

```
jne r2, 0, LBB0_3
```

This happens because LLVM branch folding pass did not have enough information to simplify branches.

**Solution**

1. Implement `analyzeBranch`, `insertBranch`, `reverseBranchCondition`,`removeBranch` and `getBranchDestBlock` correctly. I copied some functions from the aarch64 target, with specific adaptations for the SBF target.
2. (Extra): I also implemented `getInstSizeInBytes`, which LLVM uses in the branch relaxing pass.


PS: I got mixed results, because branch folding runs multiple times in codegen. Now that LLVM has information about branches, programs changed completely. Branches are now different, some instructions are sunken, while others are hoisted. Register allocation also changed in some cases.