### PR TITLE
[SOL] Do not add a return after a JA

### DIFF
--- a/.github/workflows/llvm-project-tests.yml
+++ b/.github/workflows/llvm-project-tests.yml
@@ -44,7 +44,7 @@ on:
         # to install a python version linked against a newer version of glibc.
         # TODO(boomanaiden154): Bump the Ubuntu version once the version in the
         # container is bumped.
-        default: '["ubuntu-22.04", "windows-2019", "macOS-13"]'
+        default: '["ubuntu-22.04", "windows-2022", "macOS-13"]'
 
       python_version:
         required: false
@@ -74,7 +74,7 @@ jobs:
           - ubuntu-22.04
           # Use windows-2019 due to:
           # https://developercommunity.visualstudio.com/t/Prev-Issue---with-__assume-isnan-/1597317
-          - windows-2019
+          - windows-2022
           # We're using a specific version of macOS due to:
           # https://github.com/actions/virtual-environments/issues/5900
           - macOS-latest

--- a/llvm/lib/Target/SBF/SBFMIPeephole.cpp
+++ b/llvm/lib/Target/SBF/SBFMIPeephole.cpp
@@ -187,23 +187,21 @@ bool SBFMIPreEmitPeephole::addReturn() {
   //
   // Although we can change ISelLowering and manually add the return for an
   // LLVM-IR unreachable instruction, LLVM codegen uses the target machine's
-  // return instruction to determine whether a function needs an epilogue,
-  // increasing code size more, even when we know the call won't transfer
-  // control back to the caller.
+  // return instruction to determine whether a function needs an epilogue.
+  // This setting increases code size, even when we know the call won't
+  // trasnfer control back to the caller.
   //
   // In that case, we can analyze every function before emitting machine code
   // and include a useless return instruction.
 
-  for (MachineBasicBlock &MBB: *MF) {
-    if (!MBB.succ_empty() || MBB.empty())
-      continue;
-
-    MachineInstr &MI = MBB.back();
-    unsigned Opcode = MI.getOpcode();
-    if (Opcode != SBF::RETURN_v3 && Opcode != SBF::JMP) {
-      BuildMI(&MBB, MI.getDebugLoc(), TII->get(SBF::RETURN_v3));
-      Added = true;
-    }
+  // PreEmitPeephole happens after block placement, so the last block in
+  // the ELF layout is also the last one in MF.
+  MachineBasicBlock &MBB = MF->back();
+  MachineInstr &MI = MBB.back();
+  unsigned Opcode = MI.getOpcode();
+  if (Opcode != SBF::RETURN_v3 && Opcode != SBF::JMP) {
+    BuildMI(&MBB, MI.getDebugLoc(), TII->get(SBF::RETURN_v3));
+    Added = true;
   }
 
   return Added;

--- a/llvm/lib/Target/SBF/SBFMIPeephole.cpp
+++ b/llvm/lib/Target/SBF/SBFMIPeephole.cpp
@@ -200,7 +200,7 @@ bool SBFMIPreEmitPeephole::addReturn() {
 
     MachineInstr &MI = MBB.back();
     unsigned Opcode = MI.getOpcode();
-    if (Opcode != SBF::RETURN_v3) {
+    if (Opcode != SBF::RETURN_v3 && Opcode != SBF::JMP) {
       BuildMI(&MBB, MI.getDebugLoc(), TII->get(SBF::RETURN_v3));
       Added = true;
     }


### PR DESCRIPTION
We can simplify the patch of function with the `return` instruction, if we know that last `MachineBasicBlock` is also the last block in the ELF layout.

Since `PreEmitPeephole` happens after block placement, that assumption holds.

Also, I avoided adding `return` when the last instruction is a `ja`.