### PR TITLE
[SOL] Do not add stack pointer adjustment at end

### DIFF
--- a/.github/workflows/llvm-project-tests.yml
+++ b/.github/workflows/llvm-project-tests.yml
@@ -14,7 +14,7 @@ on:
         required: false
       os_list:
         required: false
-        default: '["ubuntu-22.04", "windows-2019", "macOS-13"]'
+        default: '["ubuntu-22.04", "windows-2022", "macOS-13"]'
       python_version:
         required: false
         type: string
@@ -44,7 +44,7 @@ on:
         # to install a python version linked against a newer version of glibc.
         # TODO(boomanaiden154): Bump the Ubuntu version once the version in the
         # container is bumped.
-        default: '["ubuntu-22.04", "windows-2019", "macOS-13"]'
+        default: '["ubuntu-22.04", "windows-2022", "macOS-13"]'
 
       python_version:
         required: false
@@ -74,7 +74,7 @@ jobs:
           - ubuntu-22.04
           # Use windows-2019 due to:
           # https://developercommunity.visualstudio.com/t/Prev-Issue---with-__assume-isnan-/1597317
-          - windows-2019
+          - windows-2022
           # We're using a specific version of macOS due to:
           # https://github.com/actions/virtual-environments/issues/5900
           - macOS-latest

--- a/llvm/test/CodeGen/SBF/dynamic_stack_frame_add_not_sub.ll
+++ b/llvm/test/CodeGen/SBF/dynamic_stack_frame_add_not_sub.ll
@@ -13,7 +13,7 @@
 define i32 @test_func(ptr noundef %vec, i32 noundef %idx) #0 {
 ; CHECK-LABEL: test_func:
 ; CHECK: add64 r10, -128
-; CHECK: add64 r10, 128
+; CHECK-NOT: add64 r10, 128
 entry:
   %vec.addr = alloca ptr, align 8
   %idx.addr = alloca i512, align 4

--- a/llvm/test/CodeGen/SBF/many_args_new_conv.ll
+++ b/llvm/test/CodeGen/SBF/many_args_new_conv.ll
@@ -68,7 +68,7 @@ define i32 @callee_alloca(i32 %a, i32 %b, i32 %c, i32 %d, i32 %e, i32 %f, i32 %p
 ; CHECK: ldxdw r2, [r10 + 88]
 ; Loading allocated i32
 ; CHECK: ldxw r0, [r10 + 24]
-; CHECK: add64 r10, 128
+; CHECK-NOT: add64 r10, 128
 
 entry:
   %o = alloca i512
@@ -97,7 +97,7 @@ define i32 @callee_no_alloca(i32 %a, i32 %b, i32 %c, i32 %d, i32 %e, i32 %f, i32
 ; CHECK: ldxdw r1, [r10 + 32]
 ; CHECK: ldxdw r1, [r10 + 24]
 
-; CHECK: add64 r10, 64
+; CHECK-NOT: add64 r10, 64
 entry:
   %g = add i32 %a, %b
   %h = sub i32 %g, %c

--- a/llvm/test/CodeGen/SBF/stack_args_v2.ll
+++ b/llvm/test/CodeGen/SBF/stack_args_v2.ll
@@ -24,7 +24,7 @@ define i32 @bar(i32 %a, i32 %b, i32 %c, i32 %d, i32 %e, i32 %f) #1 {
 ; CHECK: sub64 r0, r5
 ; CHECK: ldxdw r1, [r10 + 56]
 ; CHECK: add64 r0, r1
-; CHECK: add64 r10, 64
+; CHECK-NOT: add64 r10, 64
 entry:
   %g = add i32 %a, %b
   %h = sub i32 %g, %c


### PR DESCRIPTION
The VM adjusts the stack pointer to the caller assigned value at a `return`/`exit` instruction, so we do not need to emit a `add64 reg, +imm` at the epilogue of a function.