### PR TITLE
[SOL] Create `add64 r10, 0` for functions that do not need stack space

### DIFF
--- a/llvm/lib/Target/SBF/SBFFrameLowering.cpp
+++ b/llvm/lib/Target/SBF/SBFFrameLowering.cpp
@@ -29,7 +29,7 @@ void SBFFrameLowering::emitPrologue(MachineFunction &MF,
   MachineBasicBlock::iterator MBBI = MBB.begin();
   MachineFrameInfo &MFI = MF.getFrameInfo();
   int NumBytes = (int)MFI.getStackSize();
-  if (NumBytes) {
+  if (NumBytes || MF.getSubtarget<SBFSubtarget>().getHasStaticSyscalls()) {
     DebugLoc Dl = MBBI->getDebugLoc();
     const SBFInstrInfo &TII =
         *static_cast<const SBFInstrInfo *>(MF.getSubtarget().getInstrInfo());

--- a/llvm/test/CodeGen/SBF/many_args_new_conv.ll
+++ b/llvm/test/CodeGen/SBF/many_args_new_conv.ll
@@ -1,6 +1,7 @@
 ; RUN: llc -O2 -march=sbf -mcpu=v1 < %s | FileCheck %s
 ; RUN: llc -O2 -mtriple=sbpfv1-solana-solana < %s | FileCheck %s
 ; RUN: llc -O2 -march=sbf -mcpu=v1 -mattr=+mem-encoding < %s | FileCheck %s
+; RUN: llc -O3 -march=sbf -mcpu=v3 < %s | FileCheck --check-prefix=CHECK-V3 %s
 
 ; Function Attrs: nounwind uwtable
 define i32 @caller_no_alloca(i32 %a, i32 %b, i32 %c) #0 {
@@ -9,6 +10,8 @@ entry:
 
 ; No changes to the stack pointer
 ; CHECK-NOT: add64 r10
+; Add zero to stack pointer from V3 onwards
+; CHECK-V3: add64 r10, 0
 
 ; Saving arguments on the stack
 ; CHECK: stdw [r10 - 40], 60


### PR DESCRIPTION
Such an instruction is a requirement for the new V3 verifier.