### PR TITLE
[SOL] Fix debug relocation in SBF

### DIFF
--- a/lld/ELF/InputSection.cpp
+++ b/lld/ELF/InputSection.cpp
@@ -974,7 +974,7 @@ void InputSection::relocateNonAlloc(uint8_t *buf, Relocs<RelTy> rels) {
     const uint64_t offset = rel.r_offset;
 
     // FIX: Temporary remap BPF_64_64 relocations in debug sections.
-    if (config->emachine == EM_BPF && type == R_BPF_64_64 && isDebug)
+    if (config->emachine == EM_SBF && type == R_SBF_64_64 && isDebug)
       type = R_BPF_64_ABS64;
 
     uint8_t *bufLoc = buf + offset;


### PR DESCRIPTION
**Problem**

https://github.com/anza-xyz/llvm-project/pull/65 rectified a problem in the old BPF target whereby we were emitting the wrong relocation type for debug sections.

After abandoning the `EM_BPF` machine flag, these lines were not patched.

**Solution**

Swap `BPF` by `SBF`.

The definitive fix to the wrong relocation emission is in SBPFv3. See `FeatureRelocAbs64` here:

https://github.com/anza-xyz/llvm-project/blob/29ed9cec60e17894252051458c01c773cd722fea/llvm/lib/Target/SBF/SBFTargetFeatures.td#L72
