### PR TITLE
[SOL] Emit no-op for anyext

### DIFF
--- a/llvm/lib/Target/SBF/SBFInstrInfo.td
+++ b/llvm/lib/Target/SBF/SBFInstrInfo.td
@@ -1279,7 +1279,7 @@ def : Pat<(i32 (trunc GPR:$src)),
 
 // SBFv2 anyext
 def : Pat<(i64 (anyext GPR32:$src)),
-          (MOV_32_64 GPR32:$src)>, Requires<[SBFExplicitSignExt]>;
+          (INSERT_SUBREG (i64 (IMPLICIT_DEF)), GPR32:$src, sub_32)>, Requires<[SBFExplicitSignExt]>;
 
 // SBFv1 anyext
 def : Pat<(i64 (anyext GPR32:$src)),


### PR DESCRIPTION
`anyext` is when we want to (sign or zero) extend a number, but we do not care about the high bits. In that case, the extension can be a no-op, instead of a `mov32` for v2 onwards.