### PR TITLE
[SOL] Implement `isAddImmediate` for SBF

### DIFF
--- a/llvm/lib/Target/SBF/SBFInstrInfo.cpp
+++ b/llvm/lib/Target/SBF/SBFInstrInfo.cpp
@@ -18,6 +18,7 @@
 #include "llvm/IR/DebugLoc.h"
 #include "llvm/Support/ErrorHandling.h"
 #include <cassert>
+#include <iostream>
 
 #define GET_INSTRINFO_CTOR_DTOR
 #include "SBFGenInstrInfo.inc"
@@ -399,4 +400,32 @@ unsigned SBFInstrInfo::getInstSizeInBytes(const MachineInstr &MI) const {
     return 16;
 
   return 8;
+}
+
+std::optional<RegImmPair> SBFInstrInfo::isAddImmediate(const MachineInstr &MI,
+                                         Register Reg) const {
+
+  const MachineOperand &Op0 = MI.getOperand(0);
+  if (!Op0.isReg() || Reg != Op0.getReg())
+    return std::nullopt;
+
+  if (!MI.getOperand(1).isReg() || !MI.getOperand(2).isImm())
+    return std::nullopt;
+
+  int Sign = 1;
+  int64_t Offset = 0;
+  unsigned Opcode = MI.getOpcode();
+  switch (Opcode) {
+  default:
+    return std::nullopt;
+  case SBF::SUB_ri:
+  case SBF::SUB_ri_32:
+    Sign *= -1;
+    [[fallthrough]];
+  case SBF::ADD_ri:
+  case SBF::ADD_ri_32: {
+    Offset = MI.getOperand(2).getImm() * Sign;
+    return RegImmPair{MI.getOperand(1).getReg(), Offset};
+  }
+  }
 }

--- a/llvm/lib/Target/SBF/SBFInstrInfo.cpp
+++ b/llvm/lib/Target/SBF/SBFInstrInfo.cpp
@@ -18,7 +18,6 @@
 #include "llvm/IR/DebugLoc.h"
 #include "llvm/Support/ErrorHandling.h"
 #include <cassert>
-#include <iostream>
 
 #define GET_INSTRINFO_CTOR_DTOR
 #include "SBFGenInstrInfo.inc"
@@ -403,8 +402,7 @@ unsigned SBFInstrInfo::getInstSizeInBytes(const MachineInstr &MI) const {
 }
 
 std::optional<RegImmPair> SBFInstrInfo::isAddImmediate(const MachineInstr &MI,
-                                         Register Reg) const {
-
+                                                       Register Reg) const {
   const MachineOperand &Op0 = MI.getOperand(0);
   if (!Op0.isReg() || Reg != Op0.getReg())
     return std::nullopt;

--- a/llvm/lib/Target/SBF/SBFInstrInfo.h
+++ b/llvm/lib/Target/SBF/SBFInstrInfo.h
@@ -65,6 +65,9 @@ public:
 
   unsigned getInstSizeInBytes(const MachineInstr &MI) const override;
 
+  std::optional<RegImmPair> isAddImmediate(const MachineInstr &MI,
+                                           Register Reg) const override;
+
 private:
   bool HasExplicitSignExt;
   bool NewMemEncoding;

--- a/llvm/unittests/Target/SBF/CMakeLists.txt
+++ b/llvm/unittests/Target/SBF/CMakeLists.txt
@@ -1,0 +1,20 @@
+include_directories(
+        ${LLVM_MAIN_SRC_DIR}/lib/Target/SBF
+        ${LLVM_BINARY_DIR}/lib/Target/SBF
+)
+
+set(LLVM_LINK_COMPONENTS
+        SBFCodeGen
+        SBFDesc
+        SBFInfo
+        Analysis
+        CodeGen
+        Core
+        MC
+        SelectionDAG
+        TargetParser
+)
+
+add_llvm_target_unittest(SBFTests
+        SBFInstrInfoTest.cpp
+)


### PR DESCRIPTION
**Problem**

Many functions in `SBFInstrInfo` hint LLVM optimizations and must be implemented for SBF. 

**Solution**

1. Implement `isAddImmediate`
2. Add a unit test.

PS: I made a list of functions worth implementing. Although this one appeared promising, after searching usages I only found it in the generation of dwarf information.