### PR TITLE
[SOL] Implement hints of stack stores and loads

### DIFF
--- a/llvm/lib/Target/SBF/SBFInstrInfo.cpp
+++ b/llvm/lib/Target/SBF/SBFInstrInfo.cpp
@@ -114,6 +114,41 @@ void SBFInstrInfo::storeRegToStackSlot(MachineBasicBlock &MBB,
     llvm_unreachable("Can't store this register to stack slot");
 }
 
+Register SBFInstrInfo::isStoreToStackSlot(const MachineInstr &MI,
+                                          int &FrameIndex,
+                                          unsigned &MemBytes) const {
+  switch (MI.getOpcode()) {
+  default:
+    break;
+  case SBF::STD_V2:
+  case SBF::STD_V1:
+    MemBytes = 8;
+    if (MI.getOperand(0).isReg() && MI.getOperand(1).isFI() &&
+        MI.getOperand(2).isImm() && MI.getOperand(2).getImm() == 0) {
+      FrameIndex = MI.getOperand(1).getIndex();
+      return MI.getOperand(0).getReg();
+    }
+    break;
+  case SBF::STW32_V2:
+  case SBF::STW32_V1:
+    MemBytes = 4;
+    if (MI.getOperand(0).isReg() && MI.getOperand(1).isFI() &&
+        MI.getOperand(2).isImm() && MI.getOperand(2).getImm() == 0) {
+      FrameIndex = MI.getOperand(1).getIndex();
+      return MI.getOperand(0).getReg();
+    }
+    break;
+  }
+
+  return 0;
+}
+
+Register SBFInstrInfo::isStoreToStackSlot(const MachineInstr &MI,
+                                          int &FrameIndex) const {
+  unsigned MemBytes = 0;
+  return isStoreToStackSlot(MI, FrameIndex, MemBytes);
+}
+
 void SBFInstrInfo::loadRegFromStackSlot(MachineBasicBlock &MBB,
                                         MachineBasicBlock::iterator I,
                                         Register DestReg, int FI,
@@ -134,6 +169,41 @@ void SBFInstrInfo::loadRegFromStackSlot(MachineBasicBlock &MBB,
             DestReg).addFrameIndex(FI).addImm(0);
   else
     llvm_unreachable("Can't load this register from stack slot");
+}
+
+Register SBFInstrInfo::isLoadFromStackSlot(const MachineInstr &MI,
+                                           int &FrameIndex,
+                                           unsigned &MemBytes) const {
+  switch (MI.getOpcode()) {
+  default:
+    break;
+  case SBF::LDD_V2:
+  case SBF::LDD_V1:
+    MemBytes = 8;
+    if (MI.getOperand(0).isReg() && MI.getOperand(1).isFI() &&
+        MI.getOperand(2).isImm() && MI.getOperand(2).getImm() == 0) {
+      FrameIndex = MI.getOperand(1).getIndex();
+      return MI.getOperand(0).getReg();
+    }
+    break;
+  case SBF::LDW32_V2:
+  case SBF::LDW32_V1:
+    MemBytes = 4;
+    if (MI.getOperand(0).isReg() && MI.getOperand(1).isFI() &&
+        MI.getOperand(2).isImm() && MI.getOperand(2).getImm() == 0) {
+      FrameIndex = MI.getOperand(1).getIndex();
+      return MI.getOperand(0).getReg();
+    }
+    break;
+  }
+
+  return 0;
+}
+
+Register SBFInstrInfo::isLoadFromStackSlot(const MachineInstr &MI,
+                                           int &FrameIndex) const {
+  unsigned MemBytes = 0;
+  return isLoadFromStackSlot(MI, FrameIndex, MemBytes);
 }
 
 bool SBFInstrInfo::analyzeBranch(MachineBasicBlock &MBB,

--- a/llvm/lib/Target/SBF/SBFInstrInfo.h
+++ b/llvm/lib/Target/SBF/SBFInstrInfo.h
@@ -68,6 +68,18 @@ public:
   std::optional<RegImmPair> isAddImmediate(const MachineInstr &MI,
                                            Register Reg) const override;
 
+  Register isStoreToStackSlot(const MachineInstr &MI,
+                              int &FrameIndex) const override;
+
+  Register isStoreToStackSlot(const MachineInstr &MI, int &FrameIndex,
+                              unsigned &MemBytes) const override;
+
+  Register isLoadFromStackSlot(const MachineInstr &MI,
+                               int &FrameIndex) const override;
+
+  Register isLoadFromStackSlot(const MachineInstr &MI, int &FrameIndex,
+                               unsigned &MemBytes) const override;
+
 private:
   bool HasExplicitSignExt;
   bool NewMemEncoding;

--- a/llvm/unittests/Target/SBF/SBFInstrInfoTest.cpp
+++ b/llvm/unittests/Target/SBF/SBFInstrInfoTest.cpp
@@ -125,6 +125,129 @@ TEST_P(SBFInstrInfoTest, IsAddImmediate) {
   ASSERT_FALSE(MI7Res.has_value());
 }
 
+TEST_P(SBFInstrInfoTest, IsStoreToStackSlot) {
+  const SBFInstrInfo *TII = ST->getInstrInfo();
+  DebugLoc DL;
+
+  MachineInstr *MI = BuildMI(*MF, DL, TII->get(SBF::STD_V2))
+                         .addReg(SBF::R1, getKillRegState(true))
+                         .addFrameIndex(10)
+                         .addImm(0)
+                         .getInstr();
+  int FI = 0;
+  unsigned Mem = 0;
+  auto MI1Res = TII->isStoreToStackSlot(*MI, FI, Mem);
+  EXPECT_EQ(MI1Res.id(), SBF::R1);
+  EXPECT_EQ(FI, 10);
+  EXPECT_EQ(Mem, 8u);
+
+  MI = BuildMI(*MF, DL, TII->get(SBF::STD_V1))
+           .addReg(SBF::R2, getKillRegState(true))
+           .addFrameIndex(17)
+           .addImm(0)
+           .getInstr();
+  FI = 0;
+  Mem = 0;
+  MI1Res = TII->isStoreToStackSlot(*MI, FI, Mem);
+  EXPECT_EQ(MI1Res.id(), SBF::R2);
+  EXPECT_EQ(FI, 17);
+  EXPECT_EQ(Mem, 8u);
+
+  MI = BuildMI(*MF, DL, TII->get(SBF::STW32_V2))
+           .addReg(SBF::R2, getKillRegState(true))
+           .addFrameIndex(15)
+           .addImm(0)
+           .getInstr();
+  FI = 0;
+  Mem = 0;
+  MI1Res = TII->isStoreToStackSlot(*MI, FI, Mem);
+  EXPECT_EQ(MI1Res.id(), SBF::R2);
+  EXPECT_EQ(FI, 15);
+  EXPECT_EQ(Mem, 4u);
+
+  MI = BuildMI(*MF, DL, TII->get(SBF::STW32_V1))
+           .addReg(SBF::R5, getKillRegState(true))
+           .addFrameIndex(18)
+           .addImm(0)
+           .getInstr();
+  FI = 0;
+  Mem = 0;
+  MI1Res = TII->isStoreToStackSlot(*MI, FI, Mem);
+  EXPECT_EQ(MI1Res.id(), SBF::R5);
+  EXPECT_EQ(FI, 18);
+  EXPECT_EQ(Mem, 4u);
+
+  MI = BuildMI(*MF, DL, TII->get(SBF::LDW32_V1), SBF::R1)
+           .addReg(SBF::R5, getKillRegState(true))
+           .addFrameIndex(18)
+           .addImm(0)
+           .getInstr();
+  FI = 0;
+  Mem = 0;
+  MI1Res = TII->isStoreToStackSlot(*MI, FI, Mem);
+  EXPECT_EQ(MI1Res.id(), 0u);
+}
+
+TEST_P(SBFInstrInfoTest, IsLoadFromStackSlot) {
+  const SBFInstrInfo *TII = ST->getInstrInfo();
+  DebugLoc DL;
+
+  MachineInstr *MI = BuildMI(*MF, DL, TII->get(SBF::LDD_V2), SBF::R1)
+                         .addFrameIndex(10)
+                         .addImm(0)
+                         .getInstr();
+  int FI = 0;
+  unsigned Mem = 0;
+  auto MI1Res = TII->isLoadFromStackSlot(*MI, FI, Mem);
+  EXPECT_EQ(MI1Res.id(), SBF::R1);
+  EXPECT_EQ(FI, 10);
+  EXPECT_EQ(Mem, 8u);
+
+  MI = BuildMI(*MF, DL, TII->get(SBF::LDD_V1), SBF::R2)
+           .addFrameIndex(17)
+           .addImm(0)
+           .getInstr();
+  FI = 0;
+  Mem = 0;
+  MI1Res = TII->isLoadFromStackSlot(*MI, FI, Mem);
+  EXPECT_EQ(MI1Res.id(), SBF::R2);
+  EXPECT_EQ(FI, 17);
+  EXPECT_EQ(Mem, 8u);
+
+  MI = BuildMI(*MF, DL, TII->get(SBF::LDW32_V2), SBF::R2)
+           .addFrameIndex(15)
+           .addImm(0)
+           .getInstr();
+  FI = 0;
+  Mem = 0;
+  MI1Res = TII->isLoadFromStackSlot(*MI, FI, Mem);
+  EXPECT_EQ(MI1Res.id(), SBF::R2);
+  EXPECT_EQ(FI, 15);
+  EXPECT_EQ(Mem, 4u);
+
+  MI = BuildMI(*MF, DL, TII->get(SBF::LDW32_V1))
+           .addReg(SBF::R5, getKillRegState(true))
+           .addFrameIndex(18)
+           .addImm(0)
+           .getInstr();
+  FI = 0;
+  Mem = 0;
+  MI1Res = TII->isLoadFromStackSlot(*MI, FI, Mem);
+  EXPECT_EQ(MI1Res.id(), SBF::R5);
+  EXPECT_EQ(FI, 18);
+  EXPECT_EQ(Mem, 4u);
+
+  MI = BuildMI(*MF, DL, TII->get(SBF::STD_V2))
+           .addReg(SBF::R5, getKillRegState(true))
+           .addFrameIndex(18)
+           .addImm(0)
+           .getInstr();
+  FI = 0;
+  Mem = 0;
+  MI1Res = TII->isLoadFromStackSlot(*MI, FI, Mem);
+  EXPECT_EQ(MI1Res.id(), 0u);
+}
+
 } // namespace
 
 INSTANTIATE_TEST_SUITE_P(SBFTest, SBFInstrInfoTest, testing::Values("sbf"));


### PR DESCRIPTION
**Summary**

LLVM has its internal passes InlineSpiller and StackSlotColoring, which determine the stack layout and possible spills. These passes use `isStoreToStackSlot` and `isLoadFromStackSlot` as hints, but they were not implemented.

**Solution**

Implement the two functions and their variants, and add a test.

**Remarks**

There is still a third variation of those functions `isStoreToStackSlotPostFE` and `isLoadFromStackSlotPostFE` (post PE means post frame pointer elimination). They follow a different logic and I left them out for another moment.

**Benchmarks**

This is a benchmark of the solana program entrypoint. There is one less CU for each account (the delta is based on the LLVM master branch):

| Name | CUs | Delta |
|------|------|-------|
| Account (0) | 116 | -- |
| Account (1) | 315 | -1 |
| Account (2) | 479 | -2 |
| Account (3) | 643 | -3 |
| Account (4) | 807 | -4 |
| Account (5) | 971 | -5 |
| Account (6) | 1135 | -6 |
| Account (7) | 1299 | -7 |
| Account (8) | 1463 | -8 |
| Account (16) | 2775 | -16 |
| Account (32) | 5399 | -32 |
| Account (64) | 10647 | -64 |

This is Agave's printout of the `assert_instruction_count` function (again the diff is based on the LLVM master branch):

```
  SBF program                          expected actual  diff
  solana_sbf_rust_128bit                    786   786    +0 ( +0%)
  solana_sbf_rust_alloc                    4803  4803    +0 ( +0%)
  solana_sbf_rust_custom_heap               279   279    +0 ( +0%)
  solana_sbf_rust_dep_crate                   2     2    +0 ( +0%)
  solana_sbf_rust_iter                     1413  1413    +0 ( +0%)
  solana_sbf_rust_many_args                1281  1281    +0 ( +0%)
  solana_sbf_rust_mem                      1198  1198    +0 ( +0%)
  solana_sbf_rust_membuiltins               294   294    +0 ( +0%)
  solana_sbf_rust_noop                      309   308    -1 ( -0%)
  solana_sbf_rust_param_passing             108   108    +0 ( +0%)
  solana_sbf_rust_rand                      257   257    +0 ( +0%)
  solana_sbf_rust_sanity                  17101 17101    +0 ( +0%)
  solana_sbf_rust_secp256k1_recover       88988 88412  -576 ( -1%)
  solana_sbf_rust_sha                     22758 22163  -595 ( -3%)
```