### PR TITLE
[SOL] Enable sink and fold pass for SBF

### DIFF
--- a/llvm/lib/Target/SBF/SBFTargetMachine.cpp
+++ b/llvm/lib/Target/SBF/SBFTargetMachine.cpp
@@ -81,7 +81,10 @@ namespace {
 class SBFPassConfig : public TargetPassConfig {
 public:
   SBFPassConfig(SBFTargetMachine &TM, PassManagerBase &PM)
-      : TargetPassConfig(TM, PM) {}
+      : TargetPassConfig(TM, PM) {
+    EnableSinkAndFold = true;
+    setEnableSinkAndFold(true);
+  }
 
   SBFTargetMachine &getSBFTargetMachine() const {
     return getTM<SBFTargetMachine>();

--- a/llvm/test/CodeGen/SBF/CORE/offset-reloc-pointer-2.ll
+++ b/llvm/test/CodeGen/SBF/CORE/offset-reloc-pointer-2.ll
@@ -26,7 +26,7 @@ entry:
 }
 
 ; CHECK:              mov64 r2, 12
-; CHECK-NEXT:         add64 r1, r2
+; CHECK:              add64 r1, r2
 ; CHECK:              call get_value
 
 ; CHECK:              .long   6                       # BTF_KIND_STRUCT(id = [[TID1:[0-9]+]])

--- a/llvm/test/CodeGen/SBF/sanity.ll
+++ b/llvm/test/CodeGen/SBF/sanity.ll
@@ -38,8 +38,9 @@ define void @foo_call2(i32 %a, i32 %b) #1 {
   ret void
 ; CHECK-LABEL: foo_call2:
 ; CHECK: lsh64 r2, 56
-; CHECK: arsh64 r2, 56
 ; CHECK: mov64 r1, r2
+; CHECK: arsh64 r1, 56
+; CHECK: mov64 r2, r3
 }
 
 declare void @foo_2arg(i8 signext, i32) #2


### PR DESCRIPTION
**Summary**

With a simple change, we can enable a sink and fold pass for SBF. "Sink" means LLVM will attempt to bring instructions close to their execution point to avoid unnecessary execution (as in conditional blocks). "Fold" means it will try to combine instructions when possible.

**Changes**

Set the flag boolean to true and fix failing tests.

**Benchmarks**

Testing spl token with [this suite](https://github.com/solana-program/token/blob/main/program/tests/assert_instruction_count.rs). The delta refers to the LLVM master branch.

| Name | CUs | Delta |
|------|------|-------|
| initialize_mint | 1198 | -6 |
| initialize_account | 1821 | -12 |
| mint_to | 1578 | -7 |
| transfer | 1712 | -7 |
| burn | 1530 | -8 |
| close_account | 1326 | -6 |

No changes to p-token transfer, transfer_checked, mint, initialize account, initialize mint and batch (the same ones from [this](https://github.com/solana-program/token/pull/64#issuecomment-3025043502) comment)

Solana program entry point (there were no changes to Pinocchio entry point). The delta refers to the LLVM master branch.

| Name | CUs | Delta |
|------|------|-------|
| Account (0) | 116 | -- |
| Account (1) | 311 | -4 |
| Account (2) | 472 | -7 |
| Account (3) | 633 | -10 |
| Account (4) | 794 | -13 |
| Account (5) | 955 | -16 |
| Account (6) | 1116 | -19 |
| Account (7) | 1277 | -22 |
| Account (8) | 1438 | -25 |
| Account (16) | 2726 | -49 |
| Account (32) | 5302 | -97 |
| Account (64) | 10454 | -193 |


A printout from the monorepo `assert_instruction_count` test. The diff refers to the LLVM master branch. Please, note that there was an increase in CUs for two cases. I can scrap this PR if that is an issue.

```
  SBF program                          expected actual  diff
  solana_sbf_rust_128bit                    786   784    -2 ( -0%)
  solana_sbf_rust_alloc                    4803  4803    +0 ( +0%)
  solana_sbf_rust_custom_heap               279   279    +0 ( +0%)
  solana_sbf_rust_dep_crate                   2     2    +0 ( +0%)
  solana_sbf_rust_iter                     1413  1413    +0 ( +0%)
  solana_sbf_rust_many_args                1281  1281    +0 ( +0%)
  solana_sbf_rust_mem                      1198  1195    -3 ( -0%)
  solana_sbf_rust_membuiltins               294   294    +0 ( +0%)
  solana_sbf_rust_noop                      308   304    -4 ( -1%)
  solana_sbf_rust_param_passing             108   108    +0 ( +0%)
  solana_sbf_rust_rand                      257   257    +0 ( +0%)
  solana_sbf_rust_sanity                  17101 17128   +27 ( +0%)
  solana_sbf_rust_secp256k1_recover       88412 88414    +2 ( +0%)
  solana_sbf_rust_sha                     22163 22162    -1 ( -0%)
```