### PR TITLE
[SOL] Use `mov32` to load and zero extend immediate in V2+

### DIFF
--- a/llvm/lib/Target/SBF/SBFInstrInfo.td
+++ b/llvm/lib/Target/SBF/SBFInstrInfo.td
@@ -443,7 +443,7 @@ let Predicates = [SBFExplicitSignExt], DecoderNamespace = "SBFv2" in {
                                 []>;
 }
 
-let Predicates = [SBFExplicitSignExt], DecoderNamespace = "SBFv3" in  {
+let Predicates = [SBFExplicitSignExt], DecoderNamespace = "Repeated" in  {
     def MOV_ri_32_zext : MATH_RI<SBF_ALU, SBF_MOV,
                         (outs GPR:$dst),
                         (ins i64imm:$imm),

--- a/llvm/lib/Target/SBF/SBFInstrInfo.td
+++ b/llvm/lib/Target/SBF/SBFInstrInfo.td
@@ -443,6 +443,14 @@ let Predicates = [SBFExplicitSignExt], DecoderNamespace = "SBFv2" in {
                                 []>;
 }
 
+let Predicates = [SBFExplicitSignExt], DecoderNamespace = "SBFv3" in  {
+    def MOV_ri_32_zext : MATH_RI<SBF_ALU, SBF_MOV,
+                        (outs GPR:$dst),
+                        (ins i64imm:$imm),
+                        "mov32 $dst, $imm",
+                        [(set GPR:$dst, (i64 i64immZExt32:$imm))]>;
+}
+
 def MOV_rr_32_no_sext_v1 : MATH_RR<SBF_ALU, SBF_MOV,
                         (outs GPR32:$dst),
                         (ins GPR32:$src),

--- a/llvm/test/CodeGen/SBF/mov_zext.ll
+++ b/llvm/test/CodeGen/SBF/mov_zext.ll
@@ -1,0 +1,27 @@
+; RUN: llc -march=sbf -mcpu=v1 < %s | FileCheck --check-prefix=CHECK-V1 %s
+; RUN: llc -march=sbf -mcpu=v2 < %s | FileCheck --check-prefix=CHECK-V2 %s
+
+define dso_local i64 @mov_1() {
+entry:
+; CHECK-LABEL: mov_1
+; CHECK-V1: lddw r0, 4294967294
+; CHECK-V2: mov32 r0, -2
+  ret i64 4294967294
+}
+
+define dso_local i64 @mov_2() {
+entry:
+; CHECK-LABEL: mov_2
+; CHECK-V1: lddw r0, -4294967294
+; CHECK-V2: mov32 r0, 2
+; CHECK-V2: hor64 r0, -1
+  ret i64 -4294967294
+}
+
+define dso_local i64 @mov_3() {
+entry:
+; CHECK-LABEL: mov_3
+; CHECK-V1: mov64 r0, 429496729
+; CHECK-V2: mov64 r0, 429496729
+  ret i64 429496729
+}

--- a/llvm/test/CodeGen/SBF/mov_zext.ll
+++ b/llvm/test/CodeGen/SBF/mov_zext.ll
@@ -6,6 +6,7 @@ entry:
 ; CHECK-LABEL: mov_1
 ; CHECK-V1: lddw r0, 4294967294
 ; CHECK-V2: mov32 r0, -2
+; CHECK-V2-NOT: hor64
   ret i64 4294967294
 }
 


### PR DESCRIPTION
**Problem**

For SBPFv2 onwards, we can use `mov32 reg, imm` to load and sign extend immediate values, without the pair hor64/mo32. This is particularly useful for numbers between `u32::MAX >> 1` and `u32::MAX`.

**Solution**

Create a new instruction to represent a load with zero extend. Since it has the same opcode as all the other use cases for mov32, it needs a new decoder namespace, so that LLVM knows which instruction the opcode refers to when disassembling a file.

PS: In the disassembler, we do not care which of the defined `mov32 reg, imm` the instruction we are reading is assigned to. All of them have the same syntax and semantic.