### PR TITLE
[SOL] Reduce cost of floating point expansion

### DIFF
--- a/llvm/lib/Target/SBF/SBFTargetTransformInfo.h
+++ b/llvm/lib/Target/SBF/SBFTargetTransformInfo.h
@@ -71,12 +71,14 @@ public:
       TTI::OperandValueInfo Op2Info = {TTI::OK_AnyValue, TTI::OP_None},
     ArrayRef<const Value *> Args = ArrayRef<const Value *>(),
     const Instruction *CxtI = nullptr) {
-      int ISD = TLI->InstructionOpcodeToISD(Opcode);
-      if (ISD == ISD::ADD && CostKind == TTI::TCK_RecipThroughput)
-        return SCEVCheapExpansionBudget.getValue() + 1;
+    int ISDOpcode = TLI->InstructionOpcodeToISD(Opcode);
+    
+    if ((ISDOpcode == ISD::ADD && CostKind == TTI::TCK_RecipThroughput) ||
+        !Ty->isIntOrPtrTy())
+      return SCEVCheapExpansionBudget.getValue() + 1;
 
-      return BaseT::getArithmeticInstrCost(Opcode, Ty, CostKind, Op1Info,
-                                           Op2Info);
+    return BaseT::getArithmeticInstrCost(Opcode, Ty, CostKind, Op1Info,
+                                         Op2Info);
   }
 
   TTI::MemCmpExpansionOptions enableMemCmpExpansion(bool OptSize,


### PR DESCRIPTION
**Problem**

Following the idea in https://github.com/anza-xyz/llvm-project/pull/165#issuecomment-3128492662, we can tweak the cost of arithmetic operations to reduce the number of instructions.

The method I used there removes a hack (see the comment in the PR) and standardizes the calculation of the cost from an arithmetic operation. Although it may save us up to 344 CU in the sanity program, it hurts other cases.


**Solution**

Mix the ideal solution with the BPF hack, so that we can still reap benefits for floating point operations without compromising other cases.

**Benchmarks**

A print of the `assert_instruction_count` from the monorepo:

```
  SBF program                          expected actual  diff
  solana_sbf_rust_128bit                    786   786    +0 ( +0%)
  solana_sbf_rust_alloc                    4803  4803    +0 ( +0%)
  solana_sbf_rust_custom_heap               279   279    +0 ( +0%)
  solana_sbf_rust_dep_crate                   2     2    +0 ( +0%)
  solana_sbf_rust_iter                     1413  1413    +0 ( +0%)
  solana_sbf_rust_many_args                1281  1281    +0 ( +0%)
  solana_sbf_rust_mem                      1198  1198    +0 ( +0%)
  solana_sbf_rust_membuiltins               294   294    +0 ( +0%)
  solana_sbf_rust_noop                      308   308    +0 ( +0%)
  solana_sbf_rust_param_passing             108   108    +0 ( +0%)
  solana_sbf_rust_rand                      257   257    +0 ( +0%)
  solana_sbf_rust_sanity                  17101 16969  -132 ( -1%)
  solana_sbf_rust_secp256k1_recover       88412 88412    +0 ( +0%)
  solana_sbf_rust_sha                     22163 22163    +0 ( +0%)
```

None of the other benchmarks I run showed any difference in CU. Probably because they do not involve floating point calculations.