### PR TITLE
[SOL] Expand memcmp earlier (take 2)

### DIFF
--- a/llvm/lib/Target/SBF/SBFTargetMachine.cpp
+++ b/llvm/lib/Target/SBF/SBFTargetMachine.cpp
@@ -10,12 +10,13 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include "MCTargetDesc/SBFMCAsmInfo.h"
 #include "SBF.h"
+#include "SBFFunctionInfo.h"
 #include "SBFTargetMachine.h"
 #include "SBFTargetTransformInfo.h"
-#include "SBFFunctionInfo.h"
-#include "MCTargetDesc/SBFMCAsmInfo.h"
 #include "TargetInfo/SBFTargetInfo.h"
+#include "llvm/CodeGen/ExpandMemCmp.h"
 #include "llvm/CodeGen/Passes.h"
 #include "llvm/CodeGen/TargetLoweringObjectFileImpl.h"
 #include "llvm/CodeGen/TargetPassConfig.h"
@@ -23,6 +24,7 @@
 #include "llvm/MC/TargetRegistry.h"
 #include "llvm/Passes/PassBuilder.h"
 #include "llvm/Target/TargetOptions.h"
+#include "llvm/Transforms/InstCombine/InstCombine.h"
 #include "llvm/Transforms/Scalar.h"
 #include "llvm/Transforms/Scalar/SimplifyCFG.h"
 #include "llvm/Transforms/Utils/SimplifyCFGOptions.h"
@@ -117,6 +119,8 @@ void SBFTargetMachine::registerPassBuilderCallbacks(PassBuilder &PB) {
       });
   PB.registerPeepholeEPCallback([=](FunctionPassManager &FPM,
                                     OptimizationLevel Level) {
+    FPM.addPass(ExpandMemCmpPass(this));
+    FPM.addPass(InstCombinePass());
     FPM.addPass(SimplifyCFGPass(
         SimplifyCFGOptions().hoistCommonInsts(true).convertSwitchToLookupTable(
             true)));

--- a/llvm/lib/Target/SBF/SBFTargetTransformInfo.h
+++ b/llvm/lib/Target/SBF/SBFTargetTransformInfo.h
@@ -87,6 +87,7 @@ public:
     TTI::MemCmpExpansionOptions Options;
     Options.LoadSizes = {8, 4, 2, 1};
     Options.MaxNumLoads = TLI->getMaxExpandSizeMemcmp(OptSize);
+    Options.AllowOverlappingLoads = true;
     return Options;
   }
 

--- a/llvm/test/CodeGen/SBF/expand_memcmp.ll
+++ b/llvm/test/CodeGen/SBF/expand_memcmp.ll
@@ -1,0 +1,36 @@
+; RUN: opt -O2 -S < %s | FileCheck %s
+
+target datalayout = "e-m:e-p:64:64-i64:64-n32:64-S128"
+target triple = "sbf"
+
+; Function Attrs: mustprogress nofree nounwind willreturn memory(argmem: read)
+declare i32 @memcmp(ptr nocapture, ptr nocapture, i64) local_unnamed_addr
+
+; The memcmp is expanded with an overlaping load
+define i1 @yes_expand(ptr %a, ptr %b) {
+entry:
+    %res = call i32 @memcmp(ptr %a, ptr %b, i64 15)
+    %is_zero = icmp eq i32 %res, 0
+    ret i1 %is_zero
+
+; CHECK: entry:
+; CHECK: %0 = load i64, ptr %a, align 1
+; CHECK: %1 = load i64, ptr %b, align 1
+; CHECK: %.not = icmp eq i64 %0, %1
+; CHECK: br i1 %.not, label %loadbb1, label %res_block
+
+; CHECK: res_block:
+; CHECK: br label %endblock
+
+; CHECK: loadbb1:
+; CHECK: %2 = getelementptr i8, ptr %a, i64 7
+; CHECK: %3 = getelementptr i8, ptr %b, i64 7
+; CHECK: %4 = load i64, ptr %2, align 1
+; CHECK: %5 = load i64, ptr %3, align 1
+; CHECK: %.not2 = icmp eq i64 %4, %5
+; CHECK: br i1 %.not2, label %endblock, label %res_block
+
+; CHECK: endblock:
+; CHECK: %is_zero = phi i1 [ true, %loadbb1 ], [ false, %res_block ]
+; CHECK: ret i1 %is_zero
+}


### PR DESCRIPTION
**Problem**

It has been pointed out that comparing pub keys with the equal operator consumes more CUs than it should. I found the problem to be that LLVM lowers memcmp too late in the pipeline stage, so that it still contains suboptimal code when going to machine code generation.

**Solution**

Lower memcmp earlier.

**Benchamarks**

Programs/sbf

```
  SBF program                          expected actual  diff
  solana_sbf_rust_128bit                    770   770    +0 ( +0%)
  solana_sbf_rust_alloc                    4767  4767    +0 ( +0%)
  solana_sbf_rust_custom_heap               324   324    +0 ( +0%)
  solana_sbf_rust_dep_crate                  20    20    +0 ( +0%)
  solana_sbf_rust_iter                     1513  1513    +0 ( +0%)
  solana_sbf_rust_many_args                1281  1281    +0 ( +0%)
  solana_sbf_rust_mem                      1229  1195   -34 ( -3%)
  solana_sbf_rust_membuiltins               277    69  -208 (-75%)
  solana_sbf_rust_noop                      342   342    +0 ( +0%)
  solana_sbf_rust_param_passing             108   108    +0 ( +0%)
  solana_sbf_rust_rand                      301   301    +0 ( +0%)
  solana_sbf_rust_sanity                  13578 13576    -2 ( -0%)
  solana_sbf_rust_secp256k1_recover       88376 88376    +0 ( +0%)
  solana_sbf_rust_sha                     21984 21984    +0 ( +0%)
```

No change to solana or Pinocchio entrypoint

[Pubkey comparison](https://github.com/febo/pubkey-comparison)

| Name | CUs | Delta |
|------|------|-------|
| Different | 10 | -2 |
| Same | 17 | -3 |


P-token (after reverting https://github.com/solana-program/token/pull/90 and removing pubkey_eq from Pinocchio).
The comparison is against LLVM master using p-token unmodified and this PR using p-token without pubkey_eq.

| Instruction | Master | This PR | Diff |
|-----------------|-----|-----|----|
| initialize_mint | 106 | 108 | +2 |
| initialize_account | 159 | 157 | -2 |
| initialize_multisig | 211 | 221 | +10 |
| transfer | 76 | 76 | 0 |
| approve | 129 | 136 | +5 |
| revoke | 102 | 102 | 0 |
| set_authority | 131 | 130 | -1 |
| mint_to | 124 | 123 | -1 |
| burn | 129 | 129 | 0 |
| close_account | 121 | 121 | 0 |
| freeze_account | 150 | 150 | 0 |
| thaw_account | 146 | 146 | 0 |
| transfer_checked | 105 | 105 | 0 |
| approve_checked | 169 | 183 | +14 |
| mint_to_checked | 173 | 177 | +4 |
| burn_checked | 141 | 147 | +6 |
| initialize_account2 | 176 | 179 | +3 | 
| initialize_account3 | 246 | 247 | +1|
| initialize_multisig2 | 342 | 342 | 0 |
| initialize_mint2 | 228 | 229 | +1 |
| amount_to_ui_amount | 423 | 424 | +1 |
| ui_amount_to_amount | 703 | 706 | +3 |
| initialize_immutable_owner | 38 | 38 | 0 |
| sync_native | 62 | 62 | 0 |
| batch | 1499 | 1496 | -3 |