### PR TITLE
[SOL] Change `callx` encoding for sBPFv3

### DIFF
--- a/llvm/lib/Target/SBF/Disassembler/SBFDisassembler.cpp
+++ b/llvm/lib/Target/SBF/Disassembler/SBFDisassembler.cpp
@@ -245,6 +245,9 @@ DecodeStatus SBFDisassembler::getInstruction(MCInst &Instr, uint64_t &Size,
     if (STI.hasFeature(SBF::FeatureCallxRegSrc)) {
       Result = decodeInstruction(DecoderTableSBFv264, Instr, Insn, Address,
                                  this, STI);
+    } else if (STI.hasFeature(SBF::FeatureCallxRegDst)) {
+      Result = decodeInstruction(DecoderTableSBFv364, Instr, Insn, Address,
+                                 this, STI);
     }
   }
   }

--- a/llvm/lib/Target/SBF/SBFInstrInfo.td
+++ b/llvm/lib/Target/SBF/SBFInstrInfo.td
@@ -51,8 +51,11 @@ def SBFHasNeg : Predicate<"!Subtarget->getDisableNeg()">;
 def SBFNoNeg: Predicate<"Subtarget->getDisableNeg()">;
 def SBFRevSub : Predicate<"Subtarget->getReverseSubImm()">;
 def SBFNoRevSub : Predicate<"!Subtarget->getReverseSubImm()">;
-def SBFCallxSrc : Predicate<"Subtarget->getCallXRegSrc()">, AssemblerPredicate<(all_of FeatureCallxRegSrc)>;
-def SBFNoCallxSrc : Predicate<"!Subtarget->getCallXRegSrc()">;
+def SBFCallxSrc : Predicate<"Subtarget->getCallXRegSrc() && !Subtarget->getCallXRegDst()">,
+                                                                        AssemblerPredicate<(all_of FeatureCallxRegSrc)>;
+def SBFCallxDst : Predicate<"Subtarget->getCallXRegDst() && !Subtarget->getCallXRegSrc()">,
+                                                                        AssemblerPredicate<(all_of FeatureCallxRegDst)>;
+def SBFNoCallxSrc : Predicate<"!Subtarget->getCallXRegSrc() && !Subtarget->getCallXRegDst()">;
 def SBFPqrInstr : Predicate<"Subtarget->getHasPqrClass()">;
 def SBFNoPqrInstr : Predicate<"!Subtarget->getHasPqrClass()">;
 def SBFExplicitSignExt : Predicate<"Subtarget->getHasExplicitSignExt()">;
@@ -819,6 +822,18 @@ class CALLX_SRC_REG<string OpcodeStr>
   let SBFClass = SBF_JMP;
 }
 
+class CALLX_DST_REG<string OpcodeStr>
+    : TYPE_ALU_JMP<SBF_CALL.Value, SBF_X.Value,
+                   (outs),
+                   (ins GPR:$BrDst),
+                   !strconcat(OpcodeStr, " $BrDst"),
+                   []> {
+  bits<4> BrDst;
+
+  let Inst{51-48} = BrDst;
+  let SBFClass = SBF_JMP;
+}
+
 // Jump always
 let isBranch = 1, isTerminator = 1, hasDelaySlot=0, isBarrier = 1 in {
   def JMP : BRANCH<SBF_JA, "ja", [(br bb:$BrDst)]>;
@@ -832,6 +847,9 @@ let isCall=1, hasDelaySlot=0, Uses = [R10],
   def JALX    : CALLX<"callx">, Requires<[SBFNoCallxSrc]>;
   let DecoderNamespace = "SBFv2" in {
     def JALX_v2 : CALLX_SRC_REG<"callx">, Requires<[SBFCallxSrc]>;
+  }
+  let DecoderNamespace = "SBFv3" in {
+    def JALX_v3 : CALLX_DST_REG<"callx">, Requires<[SBFCallxDst]>;
   }
 }
 
@@ -928,6 +946,7 @@ def : Pat<(SBFcall texternalsym:$dst), (JAL texternalsym:$dst)>;
 def : Pat<(SBFcall imm:$dst), (JAL imm:$dst)>;
 def : Pat<(SBFcall GPR:$dst), (JALX GPR:$dst)>, Requires<[SBFNoCallxSrc]>;
 def : Pat<(SBFcall GPR:$dst), (JALX_v2 GPR:$dst)>, Requires<[SBFCallxSrc]>;
+def : Pat<(SBFcall GPR:$dst), (JALX_v3 GPR:$dst)>, Requires<[SBFCallxDst]>;
 
 // Loads
 let Predicates = [SBFNoALU32, SBFOldMemEncoding] in {

--- a/llvm/lib/Target/SBF/SBFSubtarget.cpp
+++ b/llvm/lib/Target/SBF/SBFSubtarget.cpp
@@ -49,6 +49,7 @@ void SBFSubtarget::initializeEnvironment(const Triple &TT) {
   ReverseSubImm = false;
   NoLddw = false;
   CallxRegSrc = false;
+  CallxRegDst = false;
   HasPqrClass = false;
   HasAlu32 = false;
   HasExplicitSignExt = false;

--- a/llvm/lib/Target/SBF/SBFSubtarget.h
+++ b/llvm/lib/Target/SBF/SBFSubtarget.h
@@ -73,6 +73,9 @@ protected:
   // Whether to encode destination register in Callx's src field
   bool CallxRegSrc;
 
+  // Whether to encode destination register in Callx's dst field
+  bool CallxRegDst;
+
   // Whether we have the PQR instruction class
   bool HasPqrClass;
 
@@ -109,6 +112,7 @@ public:
   bool getReverseSubImm() const { return ReverseSubImm; }
   bool getNoLddw() const { return NoLddw; }
   bool getCallXRegSrc() const { return CallxRegSrc; }
+  bool getCallXRegDst() const { return CallxRegDst; }
   bool getHasPqrClass() const { return HasPqrClass; }
   bool getHasExplicitSignExt() const { return HasExplicitSignExt; }
   bool getNewMemEncoding() const { return NewMemEncoding; }

--- a/llvm/lib/Target/SBF/SBFTargetFeatures.td
+++ b/llvm/lib/Target/SBF/SBFTargetFeatures.td
@@ -37,6 +37,9 @@ def FeatureDisableLddw : SubtargetFeature<"no-lddw", "NoLddw", "true",
 def FeatureCallxRegSrc : SubtargetFeature<"callx-reg-src", "CallxRegSrc", "true",
                                     "Encode Callx destination register in the src field">;
 
+def FeatureCallxRegDst : SubtargetFeature<"callx-reg-dst", "CallxRegDst", "true",
+                                    "Encode Callx destination register in the dst field">;
+
 def FeaturePqrInstr : SubtargetFeature<"pqr-instr", "HasPqrClass", "true",
                                     "Enable the PQR instruction class">;
 
@@ -62,10 +65,10 @@ def : Proc<"v2", [FeatureDynamicFrames, FeatureDisableLddw,
                   FeatureDisableNeg, FeatureReverseSubImm, ALU32]>;
 
 def : Proc<"v3", [FeatureDynamicFrames, FeatureDisableLddw,
-                  FeatureNewMemEncoding, FeatureCallxRegSrc, FeaturePqrInstr, FeatureExplicitSext,
+                  FeatureNewMemEncoding, FeatureCallxRegDst, FeaturePqrInstr, FeatureExplicitSext,
                   FeatureDisableNeg, FeatureReverseSubImm, ALU32, FeatureStaticSyscalls, FeatureRelocAbs64]>;
 
 def : Proc<"v4", [FeatureDynamicFrames, FeatureDisableLddw,
-                  FeatureNewMemEncoding, FeatureCallxRegSrc, FeaturePqrInstr, FeatureExplicitSext,
+                  FeatureNewMemEncoding, FeatureCallxRegDst, FeaturePqrInstr, FeatureExplicitSext,
                   FeatureDisableNeg, FeatureReverseSubImm, ALU32, FeatureStaticSyscalls, FeatureRelocAbs64,
                   FeatureAbiV2]>;

--- a/llvm/test/CodeGen/SBF/callx.ll
+++ b/llvm/test/CodeGen/SBF/callx.ll
@@ -2,6 +2,8 @@
 ; RUN:      | FileCheck %s -check-prefixes=CHECK-v0
 ; RUN: llc < %s -march=sbf --mcpu=v2 --show-mc-encoding \
 ; RUN:      | FileCheck %s -check-prefixes=CHECK-v2
+; RUN: llc < %s -march=sbf --mcpu=v3 --show-mc-encoding \
+; RUN:      | FileCheck %s -check-prefixes=CHECK-v3
 ; source:
 ;   int test(int (*f)(void)) { return f(); }
 
@@ -11,6 +13,7 @@ entry:
   %call = tail call i32 %f() #1
 ; CHECK-v0: callx r{{[0-9]+}} # encoding: [0x8d,0x00,0x00,0x00,0x0{{[0-9]|a|b}},0x00,0x00,0x00]
 ; CHECK-v2: callx r{{[0-9]+}} # encoding: [0x8d,0x{{[0-9]}}0,0x00,0x00,0x00,0x00,0x00,0x00]
+; CHECK-v3: callx r{{[0-9]+}} # encoding: [0x8d,0x0{{[0-9]}},0x00,0x00,0x00,0x00,0x00,0x00]
   ret i32 %call
 }
 

--- a/llvm/test/MC/Disassembler/SBF/sbf-jmp.txt
+++ b/llvm/test/MC/Disassembler/SBF/sbf-jmp.txt
@@ -1,5 +1,9 @@
 # RUN: llvm-mc --disassemble %s -triple=sbf-solana-solana \
 # RUN:                          | FileCheck %s --check-prefix=CHECK-NEW
+# RUN: llvm-mc --disassemble %s -triple=sbpfv2-solana-solana \
+# RUN:                          | FileCheck %s --check-prefix=CHECK-V2
+# RUN: llvm-mc --disassemble %s -triple=sbpfv3-solana-solana \
+# RUN:                          | FileCheck %s --check-prefix=CHECK-V3
 
 # TODO: Test immediate field ranges.
 
@@ -102,6 +106,12 @@
 
 # CHECK-NEW: callx r4
 0x8d,0x00,0x00,0x00,0x04,0x00,0x00,0x00
+
+# CHECK-V2: callx r4
+0x8d,0x40,0x00,0x00,0x00,0x00,0x00,0x00
+
+# CHECK-V3: callx r4
+0x8d,0x04,0x00,0x00,0x00,0x00,0x00,0x00
 
 # CHECK-NEW: call -1
 0x85,0x10,0x00,0x00,0xff,0xff,0xff,0xff

--- a/llvm/test/MC/SBF/sbf-jmp.s
+++ b/llvm/test/MC/SBF/sbf-jmp.s
@@ -2,11 +2,16 @@
 # RUN:     | FileCheck %s --check-prefix=CHECK-ASM-NEW
 # RUN: llvm-mc %s -triple=sbpfv3-solana-solana --show-encoding \
 # RUN:     | FileCheck %s --check-prefix=CHECK-ASM-NEW
+# RUN: llvm-mc %s -triple=sbpfv2-solana-solana --show-encoding \
+# RUN:     | FileCheck %s --check-prefix=CHECK-ASM-V2
 # RUN: llvm-mc %s -triple=sbf-solana-solana --show-encoding \
 # RUN:     | FileCheck %s --check-prefix=CHECK-ASM-OLD
 # RUN: llvm-mc %s -triple=sbf-solana-solana --mcpu=v3 -filetype=obj \
 # RUN:     | llvm-objdump -d -r - \
 # RUN:     | FileCheck --check-prefix=CHECK-OBJ-NEW %s
+# RUN: llvm-mc %s -triple=sbf-solana-solana --mcpu=v2 -filetype=obj \
+# RUN:     | llvm-objdump -d -r - \
+# RUN:     | FileCheck --check-prefix=CHECK-OBJ-V2 %s
 # RUN: llvm-mc %s -triple=sbf-solana-solana -filetype=obj \
 # RUN:     | llvm-objdump -d -r - \
 # RUN:     | FileCheck --check-prefix=CHECK-OBJ-OLD %s
@@ -161,8 +166,10 @@ call 8
 
 # CHECK-OBJ-NEW: callx r4
 # CHECK-OBJ-OLD: callx r4
-# CHECK-ASM-NEW: encoding: [0x8d,0x40,0x00,0x00,0x00,0x00,0x00,0x00]
+# CHECK-OBJ-V2:  callx r4
+# CHECK-ASM-NEW: encoding: [0x8d,0x04,0x00,0x00,0x00,0x00,0x00,0x00]
 # CHECK-ASM-OLD: encoding: [0x8d,0x00,0x00,0x00,0x04,0x00,0x00,0x00]
+# CHECK-ASM-V2:  encoding: [0x8d,0x40,0x00,0x00,0x00,0x00,0x00,0x00]
 callx r4
 
 # CHECK-OBJ-OLD: exit


### PR DESCRIPTION
Following the upstream encoding, we'll change the `callx` encoding for sBPFv3.