### PR TITLE
[SOL] Fallback to default implementation of `shouldReduceLoadWidth`

### DIFF
--- a/llvm/lib/Target/SBF/SBFISelLowering.h
+++ b/llvm/lib/Target/SBF/SBFISelLowering.h
@@ -133,19 +133,6 @@ private:
     return true;
   }
 
-  // Prevent reducing load width during SelectionDag phase.
-  // Otherwise, we may transform the following
-  //   ctx = ctx + reloc_offset
-  //   ... (*(u32 *)ctx) & 0x8000...
-  // to
-  //   ctx = ctx + reloc_offset
-  //   ... (*(u8 *)(ctx + 1)) & 0x80 ...
-  // which will be rejected by the verifier.
-  bool shouldReduceLoadWidth(SDNode *Load, ISD::LoadExtType ExtTy,
-                             EVT NewVT) const override {
-    return false;
-  }
-
   bool isLegalAddressingMode(const DataLayout &DL, const AddrMode &AM,
                              Type *Ty, unsigned AS,
                              Instruction *I = nullptr) const override;

--- a/llvm/test/CodeGen/SBF/atomics_sbf.ll
+++ b/llvm/test/CodeGen/SBF/atomics_sbf.ll
@@ -56,7 +56,7 @@ entry:
 }
 
 ; CHECK-LABEL: test_xchg_64
-; CHECK: ldxdw r0, [r1 + 0]
+; CHECK: ldxw w0, [r1 + 0]
 ; CHECK: stxdw [r1 + 0], r2
 define dso_local i32 @test_xchg_64(i64* nocapture %p, i64 %v) local_unnamed_addr {
 entry:

--- a/llvm/test/CodeGen/SBF/many_args_new_conv.ll
+++ b/llvm/test/CodeGen/SBF/many_args_new_conv.ll
@@ -64,11 +64,11 @@ define i32 @callee_alloca(i32 %a, i32 %b, i32 %c, i32 %d, i32 %e, i32 %f, i32 %p
 ; CHECK-LABEL: callee_alloca
 ; CHECK: add64 r10, -128
 ; Loading arguments
-; CHECK: ldxdw r2, [r10 + 120]
-; CHECK: ldxdw r2, [r10 + 112]
-; CHECK: ldxdw r2, [r10 + 104]
-; CHECK: ldxdw r2, [r10 + 96]
-; CHECK: ldxdw r2, [r10 + 88]
+; CHECK: ldxw r2, [r10 + 120]
+; CHECK: ldxw r2, [r10 + 112]
+; CHECK: ldxw r2, [r10 + 104]
+; CHECK: ldxw r2, [r10 + 96]
+; CHECK: ldxw r2, [r10 + 88]
 ; Loading allocated i32
 ; CHECK: ldxw r0, [r10 + 24]
 ; CHECK-NOT: add64 r10, 128
@@ -94,11 +94,11 @@ define i32 @callee_no_alloca(i32 %a, i32 %b, i32 %c, i32 %d, i32 %e, i32 %f, i32
 ; CHECK-LABEL: callee_no_alloca
 ; CHECK: add64 r10, -64
 ; Loading arguments
-; CHECK: ldxdw r1, [r10 + 56]
-; CHECK: ldxdw r1, [r10 + 48]
-; CHECK: ldxdw r1, [r10 + 40]
-; CHECK: ldxdw r1, [r10 + 32]
-; CHECK: ldxdw r1, [r10 + 24]
+; CHECK: ldxw r1, [r10 + 56]
+; CHECK: ldxw r1, [r10 + 48]
+; CHECK: ldxw r1, [r10 + 40]
+; CHECK: ldxw r1, [r10 + 32]
+; CHECK: ldxw r1, [r10 + 24]
 
 ; CHECK-NOT: add64 r10, 64
 entry:

--- a/llvm/test/CodeGen/SBF/many_args_value_size.ll
+++ b/llvm/test/CodeGen/SBF/many_args_value_size.ll
@@ -27,7 +27,7 @@ start:
 ; CHECK: ldxdw r4, [r10 + 32]
 
 ; -64 + 60 = -4, so this is 5 in %b8
-; CHECK: ldxw w4, [r10 + 60]
+; CHECK: ldxb w4, [r10 + 60]
   %c0 = trunc i64 %a to i8
   %b1 = add i8 %b8, %c0
 

--- a/llvm/test/CodeGen/SBF/stack_args_v2.ll
+++ b/llvm/test/CodeGen/SBF/stack_args_v2.ll
@@ -21,7 +21,7 @@ define i32 @bar(i32 %a, i32 %b, i32 %c, i32 %d, i32 %e, i32 %f) #1 {
 ; CHECK: sub64 r0, r3
 ; CHECK: add64 r0, r4
 ; CHECK: sub64 r0, r5
-; CHECK: ldxdw r1, [r10 + 56]
+; CHECK: ldxw r1, [r10 + 56]
 ; CHECK: add64 r0, r1
 ; CHECK-NOT: add64 r10, 64
 entry:


### PR DESCRIPTION
**Problem**

When I was working on the PR for eBPF upstream, I noticed the `shouldReduceLoadWidth` function that is there to appease the kernel verifier. If we remove it, we have some gains.

**Benchmarks**

Programs/sbf

```
  SBF program                          expected actual  diff
  solana_sbf_rust_128bit                    630   630    +0 ( +0%)
  solana_sbf_rust_alloc                    4767  4767    +0 ( +0%)
  solana_sbf_rust_custom_heap               324   324    +0 ( +0%)
  solana_sbf_rust_dep_crate                  20    20    +0 ( +0%)
  solana_sbf_rust_iter                     1513  1513    +0 ( +0%)
  solana_sbf_rust_many_args                1281  1281    +0 ( +0%)
  solana_sbf_rust_mem                      1195  1194    -1 ( -0%)
  solana_sbf_rust_membuiltins                69    68    -1 ( -1%)
  solana_sbf_rust_noop                      342   342    +0 ( +0%)
  solana_sbf_rust_param_passing             108   108    +0 ( +0%)
  solana_sbf_rust_rand                      301   301    +0 ( +0%)
  solana_sbf_rust_sanity                  13576 13576    +0 ( +0%)
  solana_sbf_rust_secp256k1_recover       88376 88376    +0 ( +0%)
  solana_sbf_rust_sha                     21984 21984    +0 ( +0%)
```

No changes to Solana program or Pinocchio entrypoint.

p-token instructions:

| Instruction | Master | This PR | Diff |
|-----------------|-----|-----|----|
| initialize_mint | 108 | 108 | 0 |
| initialize_account | 157 | 157 | 0 |
| initialize_multisig | 221 | 220 | -1 |
| transfer | 76 | 76 | 0 |
| approve | 136 | 135 | -1 |
| revoke | 102 | 101 | -1 |
| set_authority | 130 | 129 | -1 |
| mint_to | 122 | 122 | 0 |
| burn | 129 | 129 | 0 |
| close_account | 120 | 120 | 0 |
| freeze_account | 150 | 149 | -1 |
| thaw_account | 146 | 145 | -1 |
| transfer_checked | 105 | 105 | 0 |
| approve_checked | 183 | 182 | -1 |
| mint_to_checked | 176 | 175 | -1 |
| burn_checked | 147 | 147 | 0 |
| initialize_account2 | 179 | 178 | -1 | 
| initialize_account3 | 247 | 247 | 0 |
| initialize_multisig2 | 342 | 341 | -1 |
| initialize_mint2 | 229 | 229 | 0 |
| amount_to_ui_amount | 424 | 423 | -1 |
| ui_amount_to_amount | 697 | 696 | -1 |
| initialize_immutable_owner | 38 | 38 | 0 |
| sync_native | 62 | 62 | 0 |
| batch | 1493 | 1493 | 0 |