### PR TITLE
[SOL] [lldb] sbf / sbpf naming confusion

### DIFF
--- a/lldb/source/Utility/ArchSpec.cpp
+++ b/lldb/source/Utility/ArchSpec.cpp
@@ -249,11 +249,11 @@ static const CoreDefinition g_core_definitions[] = {
     {eByteOrderLittle, 4, 1, 4, llvm::Triple::wasm32, ArchSpec::eCore_wasm32,
      "wasm32"},
     {eByteOrderLittle, 8, 8, 8, llvm::Triple::bpfel, ArchSpec::eCore_bpf, "bpf"},
-    {eByteOrderLittle, 8, 8, 8, llvm::Triple::sbf, ArchSpec::eCore_sbfv0, "sbf"},
-    {eByteOrderLittle, 8, 8, 8, llvm::Triple::sbf, ArchSpec::eCore_sbfv1, "sbfv1"},
-    {eByteOrderLittle, 8, 8, 8, llvm::Triple::sbf, ArchSpec::eCore_sbfv2, "sbfv2"},
-    {eByteOrderLittle, 8, 8, 8, llvm::Triple::sbf, ArchSpec::eCore_sbfv3, "sbfv3"},
-    {eByteOrderLittle, 8, 8, 8, llvm::Triple::sbf, ArchSpec::eCore_sbfv4, "sbfv4"},
+    {eByteOrderLittle, 8, 8, 8, llvm::Triple::sbf, ArchSpec::eCore_sbfv0, "sbpf"},
+    {eByteOrderLittle, 8, 8, 8, llvm::Triple::sbf, ArchSpec::eCore_sbfv1, "sbpfv1"},
+    {eByteOrderLittle, 8, 8, 8, llvm::Triple::sbf, ArchSpec::eCore_sbfv2, "sbpfv2"},
+    {eByteOrderLittle, 8, 8, 8, llvm::Triple::sbf, ArchSpec::eCore_sbfv3, "sbpfv3"},
+    {eByteOrderLittle, 8, 8, 8, llvm::Triple::sbf, ArchSpec::eCore_sbfv4, "sbpfv4"},
 };
 
 // Ensure that we have an entry in the g_core_definitions for each core. If you


### PR DESCRIPTION
**The problem**

When receving the `target.xml` from a gdb-remote it typically contains the architecture name the remote represents. This name is later used for finding the corresponding `CoreDefiniton` so that `lldb` would be able to set up the target accordingly:

https://github.com/anza-xyz/llvm-project/blob/e9617fb71b9ae6c2eaab4e5bd627202fbdbf341b/lldb/source/Utility/ArchSpec.cpp#L1093

SBFv0-v4's `CoreDefinitons` are given name strings starting with `sbfv*`. Yet when invoking the `parseBPFArch` function it's the `sbpfv*` names that are compared against the provided `ArchName` in the attempt to return the most appropriate `Triple`:

https://github.com/anza-xyz/llvm-project/blob/e9617fb71b9ae6c2eaab4e5bd627202fbdbf341b/llvm/lib/TargetParser/Triple.cpp#L421

Unittests for v0-v4 triples are only written for the `sbpfv*` cases:

https://github.com/anza-xyz/llvm-project/blob/e9617fb71b9ae6c2eaab4e5bd627202fbdbf341b/llvm/unittests/TargetParser/TripleTest.cpp#L773

To make matters worse if remote's `target.xml` contains, for example, `<architecture>sbfv1</architecture>` this later breaks `lldb` when trying to get the output of `target dump typesystem`.

**What's changed**

The aim of this patch is to prevent this confusion and align the names to using simply `sbpf*`. Structures and enums aren't touched.