### PR TITLE
[SOL] Change stack growth direction in LLVM

### DIFF
--- a/llvm/lib/Target/SBF/SBFFrameLowering.h
+++ b/llvm/lib/Target/SBF/SBFFrameLowering.h
@@ -20,12 +20,11 @@ class SBFSubtarget;
 
 class SBFFrameLowering : public TargetFrameLowering {
 public:
-  explicit SBFFrameLowering(const SBFSubtarget &sti)
-      : TargetFrameLowering(
-            TargetFrameLowering::StackGrowsDown,
-            Align(64),
-            0,
-            Align(64)) {}
+  explicit SBFFrameLowering(const bool hasStackFramesV3)
+      : TargetFrameLowering(hasStackFramesV3
+                                ? TargetFrameLowering::StackGrowsUp
+                                : TargetFrameLowering::StackGrowsDown,
+                            Align(64), 0, Align(64)) {}
 
   void emitPrologue(MachineFunction &MF, MachineBasicBlock &MBB) const override;
   void emitEpilogue(MachineFunction &MF, MachineBasicBlock &MBB) const override;

--- a/llvm/lib/Target/SBF/SBFISelLowering.cpp
+++ b/llvm/lib/Target/SBF/SBFISelLowering.cpp
@@ -400,7 +400,8 @@ SDValue SBFTargetLowering::LowerFormalArguments(
         int64_t Offset = static_cast<int64_t>(VA.getLocMemOffset() + Size);
         // Since the stack grows to the opposite direction in V3, the offset
         // is inverted.
-        if (!Subtarget->getHasDynamicFramesV3())
+        if (Subtarget->getFrameLowering()->getStackGrowthDirection() ==
+            TargetFrameLowering::StackGrowsDown)
           Offset = -Offset;
 
         const int FrameIndex =
@@ -527,7 +528,8 @@ SDValue SBFTargetLowering::LowerCall(TargetLowering::CallLoweringInfo &CLI,
 
       // Since the stack grows to the opposite direction in V3, the offset
       // is inverted.
-      if (Subtarget->getHasDynamicFramesV3())
+      if (Subtarget->getFrameLowering()->getStackGrowthDirection() ==
+          TargetFrameLowering::StackGrowsUp)
         Offset = -Offset;
 
       int FrameIndex = MF.getFrameInfo().CreateFixedObject(

--- a/llvm/lib/Target/SBF/SBFISelLowering.cpp
+++ b/llvm/lib/Target/SBF/SBFISelLowering.cpp
@@ -397,11 +397,16 @@ SDValue SBFTargetLowering::LowerFormalArguments(
         // In the new convention, arguments are in at the end of the callee
         // frame.
         uint64_t Size = VA.getLocVT().getFixedSizeInBits() / 8;
-        int64_t Offset = -static_cast<int64_t>(VA.getLocMemOffset() + Size);
-        int FrameIndex =
+        int64_t Offset = static_cast<int64_t>(VA.getLocMemOffset() + Size);
+        // Since the stack grows to the opposite direction in V3, the offset
+        // is inverted.
+        if (!Subtarget->getHasDynamicFramesV3())
+          Offset = -Offset;
+
+        const int FrameIndex =
             MF.getFrameInfo().CreateFixedObject(Size, Offset, false);
-        SDValue DstAddr = DAG.getFrameIndex(FrameIndex, PtrVT);
-        MachinePointerInfo DstInfo =
+        const SDValue DstAddr = DAG.getFrameIndex(FrameIndex, PtrVT);
+        const MachinePointerInfo DstInfo =
             MachinePointerInfo::getFixedStack(MF, FrameIndex, Offset);
         SDV = DAG.getLoad(LocVT, DL, Chain, DstAddr, DstInfo);
       } else {
@@ -519,6 +524,11 @@ SDValue SBFTargetLowering::LowerCall(TargetLowering::CallLoweringInfo &CLI,
         // the caller.
         Offset += Size;
       }
+
+      // Since the stack grows to the opposite direction in V3, the offset
+      // is inverted.
+      if (Subtarget->getHasDynamicFramesV3())
+        Offset = -Offset;
 
       int FrameIndex = MF.getFrameInfo().CreateFixedObject(
           Size, Offset, false);

--- a/llvm/lib/Target/SBF/SBFRegisterInfo.cpp
+++ b/llvm/lib/Target/SBF/SBFRegisterInfo.cpp
@@ -149,10 +149,9 @@ int SBFRegisterInfo::resolveInternalFrameIndex(
   const SBFFunctionInfo *SBFFuncInfo = MF.getInfo<SBFFunctionInfo>();
   int Offset = MFI.getObjectOffset(FI);
   const SBFSubtarget & SubTarget = MF.getSubtarget<SBFSubtarget>();
-  uint64_t StackSize = MFI.getStackSize();
+  const uint64_t StackSize = MFI.getStackSize();
 
-  if (!SubTarget.getHasDynamicFrames() &&
-      SBFFuncInfo->containsFrameIndex(FI)) {
+  if (!SubTarget.getHasDynamicFrames() && SBFFuncInfo->containsFrameIndex(FI)) {
     Offset = SBFRegisterInfo::FrameLength - Offset;
     if (static_cast<uint64_t>(Offset) < StackSize) {
       dbgs() << "Error: A function call in method "
@@ -165,12 +164,8 @@ int SBFRegisterInfo::resolveInternalFrameIndex(
     return -Offset;
   }
 
-  if (SubTarget.getHasDynamicFrames() &&
-      SBFFuncInfo->containsFrameIndex(FI)) {
-    if (SubTarget.isDynamicFramesV1())
-      return -Offset;
-
-    return Offset;
+  if (SubTarget.getHasDynamicFrames() && SBFFuncInfo->containsFrameIndex(FI)) {
+    return -Offset;
   }
 
   Offset += Imm.value_or(0);
@@ -180,9 +175,10 @@ int SBFRegisterInfo::resolveInternalFrameIndex(
       return Offset + static_cast<int>(StackSize);
 
     if (SubTarget.getOptimizeStackSpace())
-      return -(Offset + static_cast<int>(StackSize));
+      return Offset -static_cast<int>(StackSize);
 
-    return -(Offset + std::max(static_cast<int>(StackSize), static_cast<int>(FrameLength)));
+    return Offset -
+           std::max(static_cast<int>(StackSize), static_cast<int>(FrameLength));
   }
 
   return Offset;

--- a/llvm/lib/Target/SBF/SBFSubtarget.cpp
+++ b/llvm/lib/Target/SBF/SBFSubtarget.cpp
@@ -66,9 +66,12 @@ void SBFSubtarget::initSubtargetFeatures(StringRef CPU, StringRef FS) {
 
 SBFSubtarget::SBFSubtarget(const Triple &TT, const std::string &CPU,
                            const std::string &FS, const TargetMachine &TM)
-    : SBFGenSubtargetInfo(TT, cpuFromSubArch(TT, CPU), /*TuneCPU*/ cpuFromSubArch(TT, CPU), FS), InstrInfo(),
-      FrameLowering(initializeSubtargetDependencies(TT, cpuFromSubArch(TT, CPU), FS)),
-      TLInfo(TM, *this) {
+: SBFGenSubtargetInfo(TT, cpuFromSubArch(TT, CPU),
+                      /*TuneCPU*/ cpuFromSubArch(TT, CPU), FS),
+  InstrInfo(), FrameLowering(initializeSubtargetDependencies(
+                                 TT, cpuFromSubArch(TT, CPU), FS)
+                                 .getHasDynamicFramesV3()),
+  TLInfo(TM, *this) {
   assert(TT.getArch() == Triple::sbf && "expected Triple::sbf");
 
   CallLoweringInfo.reset(new SBFCallLowering(*getTargetLowering()));

--- a/llvm/lib/Target/SBF/SBFSubtarget.cpp
+++ b/llvm/lib/Target/SBF/SBFSubtarget.cpp
@@ -66,11 +66,11 @@ void SBFSubtarget::initSubtargetFeatures(StringRef CPU, StringRef FS) {
 
 SBFSubtarget::SBFSubtarget(const Triple &TT, const std::string &CPU,
                            const std::string &FS, const TargetMachine &TM)
-: SBFGenSubtargetInfo(TT, cpuFromSubArch(TT, CPU),
-                      /*TuneCPU*/ cpuFromSubArch(TT, CPU), FS),
-  InstrInfo(), FrameLowering(initializeSubtargetDependencies(
-                                 TT, cpuFromSubArch(TT, CPU), FS)
-                                 .getHasDynamicFramesV3()),
+  : SBFGenSubtargetInfo(TT, cpuFromSubArch(TT, CPU),
+                        /*TuneCPU*/ cpuFromSubArch(TT, CPU), FS),
+    InstrInfo(), FrameLowering(initializeSubtargetDependencies(
+                                   TT, cpuFromSubArch(TT, CPU), FS)
+                                   .getHasDynamicFramesV3()),
   TLInfo(TM, *this) {
   assert(TT.getArch() == Triple::sbf && "expected Triple::sbf");
 

--- a/llvm/lib/Target/SBF/SBFSubtarget.h
+++ b/llvm/lib/Target/SBF/SBFSubtarget.h
@@ -122,6 +122,7 @@ public:
   bool isDynamicFramesV1() const {
     return HasDynamicFrames;
   }
+  bool getHasDynamicFramesV3() const { return HasDynamicFramesV3; }
   bool getUseDwarfRIS() const { return UseDwarfRIS; }
   bool getDisableNeg() const { return DisableNeg; }
   bool getReverseSubImm() const { return ReverseSubImm; }

--- a/llvm/test/CodeGen/SBF/many_args_new_conv.ll
+++ b/llvm/test/CodeGen/SBF/many_args_new_conv.ll
@@ -40,7 +40,8 @@ define i32 @caller_alloca(i32 %a, i32 %b, i32 %c) #0 {
 ; 88 is 8*7 + 32
 
 ; CHECK-V3: add64 r10, 64
-; CHECK-V3: ldxw r1, [r10 - 88]
+; CHECK-V3: ldxw r1, [r10 - 4104]
+; 4096 + 64 - 8*7 = 4104
 
 ; Saving arguments in the callee's frame
 
@@ -70,7 +71,7 @@ define i32 @caller_alloca(i32 %a, i32 %b, i32 %c) #0 {
 ; CHECK: mov64 r5, 2
 ; CHECK: call callee_no_alloca
 ; CHECK: ldxw r1, [r10 + 16]
-; CHECK-V3: ldxw r1, [r10 - 16]
+; CHECK-V3: ldxw r1, [r10 - 32]
 
 entry:
   %g = alloca [4128 x i8], align 8
@@ -104,7 +105,7 @@ define i32 @callee_alloca(i32 %a, i32 %b, i32 %c, i32 %d, i32 %e, i32 %f, i32 %p
 ; CHECK-V3: ldxw r2, [r10 - 5024]
 ; CHECK-V3: ldxw r2, [r10 - 5016]
 ; Loading allocated i32
-; CHECK-V3: ldxw r0, [r10 - 16]
+; CHECK-V3: ldxw r0, [r10 - 5008]
 
 
 ; CHECK-NOT: add64 r10, 128

--- a/llvm/test/CodeGen/SBF/many_args_new_conv_opt.ll
+++ b/llvm/test/CodeGen/SBF/many_args_new_conv_opt.ll
@@ -27,9 +27,8 @@ entry:
 define i32 @caller_alloca(i32 %a, i32 %b, i32 %c) #0 {
 ; CHECK-LABEL: caller_alloca
 ; CHECK: add64 r10, -896
-; CHECK: ldxw r1, [r10 - 128]
-; 88 is 8*7 + 32
-
+; CHECK: ldxw r1, [r10 - 3144]
+; 4096 - 896 + 56 = 3144
 
 ; Saving arguments in the callee's frame
 
@@ -47,7 +46,7 @@ define i32 @caller_alloca(i32 %a, i32 %b, i32 %c) #0 {
 ; CHECK: mov64 r4, 1
 ; CHECK: mov64 r5, 2
 ; CHECK: call callee_no_alloca
-; CHECK: ldxw r1, [r10 - 56]
+; CHECK: ldxw r1, [r10 - 72]
 
 entry:
   %g = alloca [3128 x i8], align 8
@@ -72,7 +71,7 @@ define i32 @callee_alloca(i32 %a, i32 %b, i32 %c, i32 %d, i32 %e, i32 %f, i32 %p
 ; CHECK: ldxw r2, [r10 - 3040]
 ; CHECK: ldxw r2, [r10 - 3032]
 ; Loading allocated i32
-; CHECK-V3: ldxw r0, [r10 - 32]
+; CHECK-V3: ldxw r0, [r10 - 3024]
 
 
 ; CHECK-NOT: add64 r10, 128


### PR DESCRIPTION
**Problem**

https://github.com/anza-xyz/llvm-project/pull/181 had effectively changed the direction of stack growth inside each function frame, but it did not change the main setting that tells LLVM the stack direction growth:

https://github.com/anza-xyz/llvm-project/blob/cefd64747bb027d9755efa4d674ee4cf5772e7c2/llvm/lib/Target/SBF/SBFFrameLowering.h#L25

PS: This is what happens when you only test with unit tests and not with a functional VM (that wasn't available before).

**Solution**

Change the setting and fix offsets.