### PR TITLE
[SOL] Remove ALU32 from default set of features for V3 and V4

### DIFF
--- a/llvm/lib/Target/SBF/SBFTargetFeatures.td
+++ b/llvm/lib/Target/SBF/SBFTargetFeatures.td
@@ -72,8 +72,8 @@ def : Proc<"v2", [FeatureDynamicFrames, FeatureDisableLddw,
                   FeatureNewMemEncoding, FeatureCallxRegSrc, FeaturePqrInstr, FeatureExplicitSext,
                   FeatureDisableNeg, FeatureReverseSubImm, ALU32]>;
 
-def : Proc<"v3", [ALU32, FeatureStaticSyscalls, FeatureRelocAbs64, FeatureJmp32,
+def : Proc<"v3", [FeatureStaticSyscalls, FeatureRelocAbs64, FeatureJmp32,
                   FeatureDynamicFramesV3, FeatureCallxRegDst]>;
 
-def : Proc<"v4", [ALU32, FeatureStaticSyscalls, FeatureRelocAbs64, FeatureJmp32,
+def : Proc<"v4", [FeatureStaticSyscalls, FeatureRelocAbs64, FeatureJmp32,
                   FeatureDynamicFramesV3, FeatureCallxRegDst]>;

--- a/llvm/test/CodeGen/SBF/objdump_trivial.ll
+++ b/llvm/test/CodeGen/SBF/objdump_trivial.ll
@@ -1,4 +1,4 @@
-; RUN: llc -march=sbf -mcpu=v3 -filetype=obj -o - %s | llvm-objdump -d - | FileCheck %s
+; RUN: llc -march=sbf -mcpu=v3 -mattr=+alu32 -filetype=obj -o - %s | llvm-objdump -d - | FileCheck %s
 
 ; CHECK: jslt32 w1, 0x0,
 ; CHECK: call 0x1


### PR DESCRIPTION
**Problem**

The ALU32 feature enables 32-bit arithmetic operations and the JMP32 instruction class. From some tests I ran, it looks like gains are limited to specific cases.

Programs in programs/sbf (comparing between no-alu32 and alu32):

```
SBF program                          expected actual  diff
  solana_sbf_rust_128bit                    630   627    -3 ( -0%)
  solana_sbf_rust_alloc                    4767  4773    +6 ( +0%)
  solana_sbf_rust_custom_heap               321   321    +0 ( +0%)
  solana_sbf_rust_dep_crate                  20    20    +0 ( +0%)
  solana_sbf_rust_iter                     1513  1513    +0 ( +0%)
  solana_sbf_rust_many_args                1278  1285    +7 ( +1%)
  solana_sbf_rust_mem                      1191  1191    +0 ( +0%)
  solana_sbf_rust_membuiltins                68    74    +6 ( +9%)
  solana_sbf_rust_noop                      338   340    +2 ( +1%)
  solana_sbf_rust_param_passing             108   108    +0 ( +0%)
  solana_sbf_rust_rand                      298   298    +0 ( +0%)
  solana_sbf_rust_sanity                  13573 13634   +61 ( +0%)
  solana_sbf_rust_secp256k1_recover       88244 88203   -41 ( -0%)
  solana_sbf_rust_sha                     21924 20901 -1023 ( -5%)
```

I also tested with my usual anchor tic-tac-toe game, and got +12 CUs for the setup game instruction and +5 CUs for the play instructions.

Just because the new VM was just released (and is not yet patched in Mollusk or Lite-SVM), I couldn't run the comparison in many scenarios.


**Solution**

I'll remove ALU32 from the set of default instructions and offer it as an opt-in setting. It is always possible to run more tests in the future and enable it by default later, since removing CUs is always welcome.