### PR TITLE
[SOL] Adjust offsets for stack arguments sBPFv3

### DIFF
--- a/llvm/lib/Target/SBF/SBFISelLowering.cpp
+++ b/llvm/lib/Target/SBF/SBFISelLowering.cpp
@@ -396,13 +396,15 @@ SDValue SBFTargetLowering::LowerFormalArguments(
       if (Subtarget->getHasNoStackGaps()) {
         // In the new convention, arguments are in at the end of the callee
         // frame.
-        uint64_t Size = VA.getLocVT().getFixedSizeInBits() / 8;
-        int64_t Offset = static_cast<int64_t>(VA.getLocMemOffset() + Size);
-        // Since the stack grows to the opposite direction in V3, the offset
-        // is inverted.
+        const int64_t Size =
+          static_cast<int64_t>(VA.getLocVT().getFixedSizeInBits() / 8);
+        int64_t Offset = VA.getLocMemOffset();
+
+        // Only when the stack grows down do we need to reverse the offset
+        // and compensate for the size.
         if (Subtarget->getFrameLowering()->getStackGrowthDirection() ==
             TargetFrameLowering::StackGrowsDown)
-          Offset = -Offset;
+          Offset = -Offset - Size;
 
         const int FrameIndex =
             MF.getFrameInfo().CreateFixedObject(Size, Offset, false);

--- a/llvm/lib/Target/SBF/SBFRegisterInfo.cpp
+++ b/llvm/lib/Target/SBF/SBFRegisterInfo.cpp
@@ -170,6 +170,13 @@ int SBFRegisterInfo::resolveInternalFrameIndex(llvm::MachineFunction &MF,
   }
 
   if (SubTarget.getHasNoStackGaps() && SBFFuncInfo->containsFrameIndex(FI)) {
+    // When the stack grows up, the argument offset is off by the size of the
+    // object because LLVM interprets that offset zero belongs to the caller,
+    // not the callee.
+    // PS: We have incremented it in fn LowerCall at SBFISellLowering.
+    if (SubTarget.stackGrowsUp())
+      return -(static_cast<int>(MFI.getObjectSize(FI)) + Offset);
+
     return -Offset;
   }
 

--- a/llvm/lib/Target/SBF/SBFRegisterInfo.cpp
+++ b/llvm/lib/Target/SBF/SBFRegisterInfo.cpp
@@ -173,7 +173,7 @@ int SBFRegisterInfo::resolveInternalFrameIndex(llvm::MachineFunction &MF,
     // When the stack grows up, the argument offset is off by the size of the
     // object because LLVM interprets that offset zero belongs to the caller,
     // not the callee.
-    // PS: We have incremented it in fn LowerCall at SBFISellLowering.
+    // PS: We have incremented it in fn LowerCall at SBFISelLowering.
     if (SubTarget.stackGrowsUp())
       return -(static_cast<int>(MFI.getObjectSize(FI)) + Offset);
 

--- a/llvm/test/CodeGen/SBF/many_args_new_conv.ll
+++ b/llvm/test/CodeGen/SBF/many_args_new_conv.ll
@@ -18,11 +18,11 @@ entry:
 ; CHECK: stdw [r10 - 16], 4
 ; CHECK: stdw [r10 - 8], 3
 
-; CHECK-V3: stdw [r10 + 40], 60
-; CHECK-V3: stdw [r10 + 32], 55
-; CHECK-V3: stdw [r10 + 24], 50
-; CHECK-V3: stdw [r10 + 16], 4
-; CHECK-V3: stdw [r10 + 8], 3
+; CHECK-V3: stdw [r10 + 32], 60
+; CHECK-V3: stdw [r10 + 24], 55
+; CHECK-V3: stdw [r10 + 16], 50
+; CHECK-V3: stdw [r10 + 8], 4
+; CHECK-V3: stdw [r10 + 0], 3
 
 ; CHECK: mov64 r4, 1
 ; CHECK: mov64 r5, 2
@@ -40,7 +40,7 @@ define i32 @caller_alloca(i32 %a, i32 %b, i32 %c) #0 {
 ; 1088 - 1024 + 56 = 120
 
 ; CHECK-V3: ldxw r1, [r10 - 4040]
-; 4096 - 8*7 = 4104
+; -4096 + 8*7 = -4040
 
 ; Saving arguments in the callee's frame
 
@@ -55,16 +55,16 @@ define i32 @caller_alloca(i32 %a, i32 %b, i32 %c) #0 {
 ; Offset in the callee: frame_size - 8
 ; CHECK: stdw [r10 - 8], 3
 
-; Offset in the callee: frame_size - 40
-; CHECK-V3: stdw [r10 + 40], 60
-; Offset in the callee: frame_size - 32
-; CHECK-V3: stdw [r10 + 32], 55
-; Offset in the callee: frame_size - 24
-; CHECK-V3: stdw [r10 + 24], 50
-; Offset in the callee: frame_size - 16
-; CHECK-V3: stdw [r10 + 16], 4
-; Offset in the callee: frame_size - 8
-; CHECK-V3: stdw [r10 + 8], 3
+; Offset in the callee: -frame_size + 32
+; CHECK-V3: stdw [r10 + 32], 60
+; Offset in the callee: -frame_size + 24
+; CHECK-V3: stdw [r10 + 24], 55
+; Offset in the callee: -frame_size + 16
+; CHECK-V3: stdw [r10 + 16], 50
+; Offset in the callee: -frame_size + 8
+; CHECK-V3: stdw [r10 + 8], 4
+; Offset in the callee: -frame_size + 0
+; CHECK-V3: stdw [r10 + 0], 3
 
 ; CHECK: mov64 r4, 1
 ; CHECK: mov64 r5, 2
@@ -97,13 +97,13 @@ define i32 @callee_alloca(i32 %a, i32 %b, i32 %c, i32 %d, i32 %e, i32 %f, i32 %p
 ; Loading allocated i32
 ; CHECK: ldxw r0, [r10 + 24]
 
+; CHECK-V3: ldxw r2, [r10 - 4096]
 ; CHECK-V3: ldxw r2, [r10 - 4088]
 ; CHECK-V3: ldxw r2, [r10 - 4080]
 ; CHECK-V3: ldxw r2, [r10 - 4072]
 ; CHECK-V3: ldxw r2, [r10 - 4064]
-; CHECK-V3: ldxw r2, [r10 - 4056]
 ; Loading allocated i32
-; CHECK-V3: ldxw r0, [r10 - 4048]
+; CHECK-V3: ldxw r0, [r10 - 4056]
 
 
 ; CHECK-NOT: add64 r10, 128
@@ -138,11 +138,11 @@ define i32 @callee_no_alloca(i32 %a, i32 %b, i32 %c, i32 %d, i32 %e, i32 %f, i32
 ; CHECK: ldxw r1, [r10 + 24]
 
 ; Loading arguments
+; CHECK-V3: ldxw r1, [r10 - 4096]
 ; CHECK-V3: ldxw r1, [r10 - 4088]
 ; CHECK-V3: ldxw r1, [r10 - 4080]
 ; CHECK-V3: ldxw r1, [r10 - 4072]
 ; CHECK-V3: ldxw r1, [r10 - 4064]
-; CHECK-V3: ldxw r1, [r10 - 4056]
 
 ; CHECK-NOT: add64 r10, 64
 entry:

--- a/llvm/test/CodeGen/SBF/many_args_value_size.ll
+++ b/llvm/test/CodeGen/SBF/many_args_value_size.ll
@@ -11,10 +11,10 @@ start:
 ; CHECK: stw [r10 - 12], 65516
 ; CHECK: stw [r10 - 4], 5
 
-; CHECK-V3: stdw [r10 + 32], 5400
-; CHECK-V3: stw [r10 + 20], 300
-; CHECK-V3: stw [r10 + 12], 65516
-; CHECK-V3: stw [r10 + 4], 5
+; CHECK-V3: stdw [r10 + 24], 5400
+; CHECK-V3: stw [r10 + 16], 300
+; CHECK-V3: stw [r10 + 8], 65516
+; CHECK-V3: stw [r10 + 0], 5
 
   %res = call i64 @func(i64 %a, i64 %b, i64 %c, i64 %d, i64 %e, i8 5, i16 -20, i32 300, i64 5400)
   ret i64 %res
@@ -32,27 +32,27 @@ start:
 
 ; -64 + 32 = -32, so this is 5400 in %a5
 ; CHECK: ldxdw r4, [r10 + 32]
-; 4096 - 32 = 4064
-; CHECK-V3: ldxdw r4, [r10 - 4064]
+; 4096 - 4072 = 24
+; CHECK-V3: ldxdw r4, [r10 - 4072]
 
 ; -64 + 60 = -4, so this is 5 in %b8
 ; CHECK: ldxb w4, [r10 + 60]
-; 4096 - 4 = 4092
-; CHECK-V3: ldxb w4, [r10 - 4092]
+; 4096 - 4096 = 0
+; CHECK-V3: ldxb w4, [r10 - 4096]
   %c0 = trunc i64 %a to i8
   %b1 = add i8 %b8, %c0
 
 ; -64 + 52 = -12, so this is -20 in %b16
 ; CHECK: ldxh w1, [r10 + 52]
-; 4096 - 12 = 4084
-; CHECK-V3: ldxh w1, [r10 - 4084]
+; 4096 - 4088 = 8
+; CHECK-V3: ldxh w1, [r10 - 4088]
   %c1 = trunc i64 %b to i16
   %b2 = add i16 %b16, %c1
 
 ; -64 + 44 = -20, so this is 300 in %b32
 ; CHECK: ldxw w1, [r10 + 44]
-; 4096 - 20 = 4076
-; CHECK-V3: ldxw w1, [r10 - 4076]
+; 4096 - 4080 = 16
+; CHECK-V3: ldxw w1, [r10 - 4080]
   %c2 = trunc i64 %c to i32
   %b3 = add i32 %b32, %c2
 


### PR DESCRIPTION
**Problem**

While testing sbpfv3, I noticed I was incorrectly summing up the argument size on the stack, leading to bug where we would overwrite the stack argument.

**Solution**

When the stack grows up only:

When lowering the call, we sum the size with the offset, but when calculating the load/store offset, we must subtract the size again. This is because a stack object with offset zero belongs to the caller for LLVM.

When lowering the arguments, we don't need to compensate for the size, since we want the first stack argument to already be at -4096.