### PR TITLE
[SOL] Add input deserializer abiv1, save-output command, and Python path docs

### DIFF
--- a/lldb/docs/solana/README_SOLANA_LLDB_PYTHON.md
+++ b/lldb/docs/solana/README_SOLANA_LLDB_PYTHON.md
@@ -1,0 +1,129 @@
+# Solana LLDB Python Issues
+
+This document describes Python module path issues when using `solana-lldb` across different operating systems.
+
+## Ubuntu 22.04
+
+Ubuntu 22.04 ships with Python 3.10, which is the version Solana platform-tools expects.
+
+### The Problem
+
+The bundled `lldb` cannot find the `lldb` module because it looks in the wrong `dist-packages` directory:
+
+```bash
+$ ~/.cache/solana/v1.53/platform-tools/llvm/bin/lldb -P
+Traceback (most recent call last):
+  File "<string>", line 1, in <module>
+ModuleNotFoundError: No module named 'lldb.embedded_interpreter'
+/home/myuser/.cache/solana/v1.53/platform-tools/llvm/local/lib/python3.10/dist-packages
+```
+
+The directory it's looking for doesn't exist:
+
+```bash
+$ ls /home/myuser/.cache/solana/v1.53/platform-tools/llvm/local/lib/python3.10/dist-packages
+ls: cannot access '...': No such file or directory
+```
+
+### The Solution
+
+Export the correct `PYTHONPATH` before running `solana-lldb`:
+
+```bash
+export PYTHONPATH=/home/myuser/.cache/solana/v1.53/platform-tools/llvm/lib/python3.10/dist-packages:$PYTHONPATH
+~/.cache/solana/v1.53/platform-tools/llvm/bin/solana-lldb
+```
+
+After setting `PYTHONPATH`, `solana-lldb` works correctly:
+
+```
+(lldb) command script import "/home/myuser/.cache/solana/v1.53/platform-tools/llvm/bin/lldb_lookup.py"
+(lldb) command script import "/home/myuser/.cache/solana/v1.53/platform-tools/llvm/bin/solana_lookup.py"
+(lldb) command source -s 0 '/home/myuser/.cache/solana/v1.53/platform-tools/llvm/bin/lldb_commands'
+Executing commands in '/home/myuser/.cache/solana/v1.53/platform-tools/llvm/bin/lldb_commands'.
+(lldb) type synthetic add -l lldb_lookup.synthetic_lookup -x ".*" --category Rust
+(lldb) type summary add -F lldb_lookup.summary_lookup  -e -x -h "^(alloc::([a-z_]+::)+)String$" --category Rust
+(lldb) type summary add -F lldb_lookup.summary_lookup  -e -x -h "^&(mut )?str$" --category Rust
+(lldb) type summary add -F lldb_lookup.summary_lookup  -e -x -h "^&(mut )?\\[.+\\]$" --category Rust
+(lldb) type summary add -F lldb_lookup.summary_lookup  -e -x -h "^(std::ffi::([a-z_]+::)+)OsString$" --category Rust
+(lldb) type summary add -F lldb_lookup.summary_lookup  -e -x -h "^(alloc::([a-z_]+::)+)Vec<.+>$" --category Rust
+(lldb) type summary add -F lldb_lookup.summary_lookup  -e -x -h "^(alloc::([a-z_]+::)+)VecDeque<.+>$" --category Rust
+(lldb) type summary add -F lldb_lookup.summary_lookup  -e -x -h "^(alloc::([a-z_]+::)+)BTreeSet<.+>$" --category Rust
+(lldb) type summary add -F lldb_lookup.summary_lookup  -e -x -h "^(alloc::([a-z_]+::)+)BTreeMap<.+>$" --category Rust
+(lldb) type summary add -F lldb_lookup.summary_lookup  -e -x -h "^(std::collections::([a-z_]+::)+)HashMap<.+>$" --category Rust
+(lldb) type summary add -F lldb_lookup.summary_lookup  -e -x -h "^(std::collections::([a-z_]+::)+)HashSet<.+>$" --category Rust
+(lldb) type summary add -F lldb_lookup.summary_lookup  -e -x -h "^(alloc::([a-z_]+::)+)Rc<.+>$" --category Rust
+(lldb) type summary add -F lldb_lookup.summary_lookup  -e -x -h "^(alloc::([a-z_]+::)+)Arc<.+>$" --category Rust
+(lldb) type summary add -F lldb_lookup.summary_lookup  -e -x -h "^(core::([a-z_]+::)+)Cell<.+>$" --category Rust
+(lldb) type summary add -F lldb_lookup.summary_lookup  -e -x -h "^(core::([a-z_]+::)+)Ref<.+>$" --category Rust
+(lldb) type summary add -F lldb_lookup.summary_lookup  -e -x -h "^(core::([a-z_]+::)+)RefMut<.+>$" --category Rust
+(lldb) type summary add -F lldb_lookup.summary_lookup  -e -x -h "^(core::([a-z_]+::)+)RefCell<.+>$" --category Rust
+(lldb) type category enable Rust
+(lldb) command source -s 0 '/home/myuser/.cache/solana/v1.53/platform-tools/llvm/bin/solana_commands'
+Executing commands in '/home/myuser/.cache/solana/v1.53/platform-tools/llvm/bin/solana_commands'.
+(lldb) type summary add -F solana_lookup.summary_lookup solana_program::account_info::AccountInfo --category Solana
+(lldb) type summary add -F solana_lookup.summary_lookup solana_program::pubkey::Pubkey --category Solana
+(lldb) type category enable Solana
+(lldb)
+```
+
+## Ubuntu 24.04
+
+### The Problem
+
+Ubuntu 24.04 ships with Python 3.12, but the Solana platform-tools depend on Python 3.10.
+
+### The Solution
+
+Install Python 3.10 from the deadsnakes PPA:
+
+```bash
+sudo apt update
+sudo apt install software-properties-common
+sudo add-apt-repository ppa:deadsnakes/ppa
+sudo apt update
+sudo apt install python3.10 python3.10-venv python3.10-dev
+```
+
+Then set the `PYTHONPATH` (same as Ubuntu 22.04):
+
+```bash
+export PYTHONPATH=~/.cache/solana/v1.53/platform-tools/llvm/lib/python3.10/dist-packages:$PYTHONPATH
+~/.cache/solana/v1.53/platform-tools/llvm/bin/solana-lldb
+```
+
+After this, `solana-lldb` works correctly and loads Rust/Solana type summaries (same output as Ubuntu 22.04).
+
+### Example: Importing and Using a Custom Script
+
+Once `solana-lldb` is working, you can import custom Python scripts:
+
+```
+(lldb) command script import ./solana_input_deserialize_abiv1.py
+Loaded. Use: solana_input_deserialize_abiv1 [addr] [max_permitted_data_increase]
+(lldb) gdb-remote 10.156.130.1:9090
+Process 1 stopped
+* thread #1, stop reason = signal SIGTRAP
+    frame #0: 0x586f010000000000
+(lldb) solana_input_deserialize_abiv1
+Deserializing at 0x400000000 (max_permitted_data_increase=10240)...
+....
+```
+
+## macOS
+
+On macOS, LLDB works out of the box because Solana platform-tools is tied to python3.14 (unlike the builds for Linux, which use python3.10 since platform-tools is built in an Ubuntu 22.04 environment).
+
+Ensure python3.14 is installed via Homebrew:
+
+```bash
+$ brew list | grep python@3.14
+python@3.14
+```
+
+```bash
+$ ~/.cache/solana/v1.53/platform-tools/llvm/bin/solana-lldb -P
+/Users/myuser/.cache/solana/v1.53/platform-tools/llvm/lib/python3.14/site-packages
+```
+
+macOS "just works" because the path to the module is correct.

--- a/lldb/scripts/solana/solana-lldb
+++ b/lldb/scripts/solana/solana-lldb
@@ -21,8 +21,17 @@ fi
 
 script_import_rust="command script import \"${here}/lldb_lookup.py\""
 script_import_solana="command script import \"${here}/solana_lookup.py\""
+script_import_solana_input_deserialize_abiv1="command script import \"${here}/solana_input_deserialize_abiv1.py\""
+script_import_solana_save_output="command script import \"${here}/solana_save_output.py\""
 commands_file_rust="${here}/lldb_commands"
 commands_file_solana="${here}/solana_commands"
 
 # Call LLDB with the commands added to the argument list
-"$lldb" --one-line-before-file "$script_import_rust" --one-line-before-file "$script_import_solana" --source-before-file "$commands_file_rust" --source-before-file "$commands_file_solana" "$@"
+"$lldb" \
+	--one-line-before-file "$script_import_rust" \
+	--one-line-before-file "$script_import_solana" \
+	--one-line-before-file "$script_import_solana_input_deserialize_abiv1" \
+	--one-line-before-file "$script_import_solana_save_output" \
+	--source-before-file "$commands_file_rust" \
+	--source-before-file "$commands_file_solana" \
+	"$@"

--- a/lldb/scripts/solana/solana_input_deserialize_abiv1.py
+++ b/lldb/scripts/solana/solana_input_deserialize_abiv1.py
@@ -1,0 +1,206 @@
+"""
+Solana Program Input Deserializer for LLDB (ABI v1)
+
+Follows the deserialization logic from:
+https://github.com/anza-xyz/solana-sdk/blob/0b0796150d3016e88b89a509db34dcf7e34afd3c/program-entrypoint/src/lib.rs#L464
+
+Usage in LLDB:
+    (lldb) command script import /path/to/solana_input_deserialize_abiv1.py
+    (lldb) solana_input_deserialize_abiv1                          # default address
+    (lldb) solana_input_deserialize_abiv1 0x400000000              # custom address
+    (lldb) solana_input_deserialize_abiv1 0x400000000 10240        # custom max_permitted_data_increase
+"""
+
+import struct
+from typing import Tuple
+
+# Constants from solana-program-entrypoint
+NON_DUP_MARKER = 0xFF
+MAX_PERMITTED_DATA_INCREASE = 10 * 1024
+BPF_ALIGN_OF_U128 = 8
+PUBKEY_SIZE = 32
+INPUT_BASE_ADDRESS = 0x400000000
+
+
+def encode_base58(data: bytes) -> str:
+    return b58encode(data).decode('ascii')
+
+
+class MemoryReader:
+    def __init__(self, process, base_address: int):
+        self.process = process
+        self.base = base_address
+
+    def read(self, offset: int, size: int) -> bytes:
+        import lldb
+        err = lldb.SBError()
+        data = self.process.ReadMemory(self.base + offset, size, err)
+        if not err.Success():
+            raise RuntimeError(f"Read failed at 0x{self.base + offset:x}: {err}")
+        return data
+
+    def u8(self, offset: int) -> int:
+        return struct.unpack('<B', self.read(offset, 1))[0]
+
+    def u32(self, offset: int) -> int:
+        return struct.unpack('<I', self.read(offset, 4))[0]
+
+    def u64(self, offset: int) -> int:
+        return struct.unpack('<Q', self.read(offset, 8))[0]
+
+    def pubkey(self, offset: int) -> str:
+        return encode_base58(self.read(offset, PUBKEY_SIZE))
+
+
+def align(offset: int) -> int:
+    return (offset + BPF_ALIGN_OF_U128 - 1) & ~(BPF_ALIGN_OF_U128 - 1)
+
+
+def format_hex(data: bytes, indent: str = "      ") -> str:
+    """Format bytes as hex, 16 bytes per line."""
+    lines = []
+    for i in range(0, len(data), 16):
+        chunk = data[i:i+16]
+        hex_str = ' '.join(f'{b:02x}' for b in chunk)
+        lines.append(f"{indent}{hex_str}")
+    return '\n'.join(lines)
+
+
+def deserialize_account(r: MemoryReader, offset: int, max_permitted_data_increase: int) -> Tuple[dict, int]:
+    acc = {}
+    acc['is_signer'] = r.u8(offset) != 0; offset += 1
+    acc['is_writable'] = r.u8(offset) != 0; offset += 1
+    acc['executable'] = r.u8(offset) != 0; offset += 1
+    acc['original_data_len'] = r.u32(offset); offset += 4
+    acc['key'] = r.pubkey(offset); offset += PUBKEY_SIZE
+    acc['owner'] = r.pubkey(offset); offset += PUBKEY_SIZE
+    acc['lamports'] = r.u64(offset); offset += 8
+    acc['data_len'] = r.u64(offset); offset += 8
+    acc['data_offset'] = offset
+    acc['data'] = r.read(offset, acc['data_len']) if acc['data_len'] > 0 else b''
+    offset += acc['data_len'] + max_permitted_data_increase
+    offset = align(offset)
+    acc['rent_epoch'] = r.u64(offset); offset += 8
+    return acc, offset
+
+
+def deserialize(r: MemoryReader, max_permitted_data_increase: int = MAX_PERMITTED_DATA_INCREASE):
+    offset = 0
+    num_accounts = r.u64(offset); offset += 8
+
+    accounts = []
+    for _ in range(num_accounts):
+        acc_offset = offset
+        dup = r.u8(offset); offset += 1
+        if dup == NON_DUP_MARKER:
+            acc, offset = deserialize_account(r, offset, max_permitted_data_increase)
+            acc['offset'] = acc_offset
+            acc['dup_marker'] = dup
+            accounts.append(acc)
+        else:
+            offset += 7  # padding
+            accounts.append({'dup_of': dup})
+
+    ix_len = r.u64(offset); offset += 8
+    ix_data_offset = offset
+    ix_data = r.read(offset, ix_len); offset += ix_len
+    program_id_offset = offset
+    program_id = r.pubkey(offset); offset += PUBKEY_SIZE
+
+    return {
+        'program_id': program_id,
+        'program_id_offset': program_id_offset,
+        'accounts': accounts,
+        'instruction_data': ix_data,
+        'instruction_data_offset': ix_data_offset,
+        'instruction_data_len': ix_len,
+        'total_size': offset,
+    }
+
+
+def format_result(result, base: int) -> str:
+    lines = []
+    lines.append("=" * 60)
+    lines.append(f"Accounts: {len(result['accounts'])}")
+    lines.append("-" * 60)
+    for i, acc in enumerate(result['accounts']):
+        if 'dup_of' in acc:
+            lines.append(f"  [{i}] DUPLICATE of #{acc['dup_of']}")
+        else:
+            lines.append(f"  [{i}] @ 0x{base + acc['offset']:x}")
+            lines.append(f"      pubkey: {acc['key']}")
+            lines.append(f"      owner: {acc['owner']}")
+            lines.append(f"      lamports: {acc['lamports']} ({acc['lamports']/1e9:.9f} SOL)")
+            lines.append(f"      rent_epoch: {acc['rent_epoch']}")
+            lines.append(f"      dup_marker: 0x{acc['dup_marker']:02x}, signer: {acc['is_signer']}, writable: {acc['is_writable']}, executable: {acc['executable']}")
+            lines.append(f"      original_data_len: {acc['original_data_len']}, data_len: {acc['data_len']}")
+            data_addr = base + acc['data_offset']
+            lines.append(f"      data @ 0x{data_addr:x}: x/{acc['data_len']}b 0x{data_addr:x}")
+            if acc['data_len'] > 0:
+                display_data = acc['data'][:128]
+                lines.append(format_hex(display_data))
+                if acc['data_len'] > 128:
+                    lines.append(f"      ... ({acc['data_len'] - 128} more bytes)")
+    lines.append("-" * 60)
+    ix_addr = base + result['instruction_data_offset']
+    ix_len = result['instruction_data_len']
+    lines.append(f"Instruction data ({ix_len} bytes @ 0x{ix_addr:x}): x/{ix_len}b 0x{ix_addr:x}")
+    if ix_len > 0:
+        display_ix = result['instruction_data'][:128]
+        lines.append(format_hex(display_ix))
+        if ix_len > 128:
+            lines.append(f"      ... ({ix_len - 128} more bytes)")
+    lines.append("-" * 60)
+    lines.append(f"Program ID: {result['program_id']} (address: 0x{base + result['program_id_offset']:x})")
+    lines.append("-" * 60)
+    lines.append(f"Total input buffer size: {result['total_size']} bytes (0x{result['total_size']:x})")
+    lines.append("=" * 60)
+    return "\n".join(lines)
+
+
+def solana_input_deserialize_abiv1_command(debugger, command, result, internal_dict):
+    args = command.strip().split()
+    base = int(args[0], 0) if len(args) > 0 else INPUT_BASE_ADDRESS
+    max_permitted_data_increase = int(args[1], 0) if len(args) > 1 else MAX_PERMITTED_DATA_INCREASE
+
+    print(f"Deserializing at 0x{base:x} (max_permitted_data_increase={max_permitted_data_increase})...")
+    try:
+        process = debugger.GetSelectedTarget().GetProcess()
+        r = MemoryReader(process, base)
+        res = deserialize(r, max_permitted_data_increase)
+        output = format_result(res, base)
+        print(output)
+    except Exception as e:
+        print(f"Error: {e}")
+        import traceback; traceback.print_exc()
+
+
+def __lldb_init_module(debugger, internal_dict):
+    debugger.HandleCommand(
+        'command script add -f solana_input_deserialize_abiv1.solana_input_deserialize_abiv1_command solana_input_deserialize_abiv1'
+    )
+    print(f"Loaded. Use: solana_input_deserialize_abiv1 [addr] [max_permitted_data_increase]")
+
+
+# =============================================================================
+# Base58 encoding
+# From: https://github.com/keis/base58 (v2.1.1)
+# License: MIT - Copyright (c) 2013 David Keijser
+# SPDX-License-Identifier: MIT
+# =============================================================================
+B58_ALPHABET = b'123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz'
+
+
+def b58encode(v: bytes) -> bytes:
+    origlen = len(v)
+    v = v.lstrip(b'\0')
+    newlen = len(v)
+
+    acc = int.from_bytes(v, byteorder='big')
+
+    result = b''
+    while acc:
+        acc, idx = divmod(acc, 58)
+        result = B58_ALPHABET[idx:idx+1] + result
+
+    return B58_ALPHABET[0:1] * (origlen - newlen) + result

--- a/lldb/scripts/solana/solana_save_output.py
+++ b/lldb/scripts/solana/solana_save_output.py
@@ -1,0 +1,85 @@
+"""
+LLDB Command Output Saver
+
+Captures the output of any LLDB command and saves it to a file.
+
+Usage in LLDB:
+    (lldb) command script import /path/to/solana_save_output.py
+    (lldb) solana_save_output /tmp/out.txt memory read 0x400000000 -c 100
+    (lldb) solana_save_output /tmp/regs.txt register read
+    (lldb) solana_save_output /tmp/bt.txt bt
+"""
+
+
+def solana_save_output_command(debugger, command, result, internal_dict):
+    import lldb
+    import sys
+    import io
+
+    raw = command.strip()
+    if raw.startswith('"') or raw.startswith("'"):
+        quote = raw[0]
+        end = raw.find(quote, 1)
+        if end == -1:
+            print("Unterminated quote in filename.")
+            return
+        filename = raw[1:end]
+        lldb_command = raw[end+1:].strip()
+    else:
+        parts = raw.split(None, 1)
+        filename = parts[0] if parts else ""
+        lldb_command = parts[1] if len(parts) > 1 else ""
+
+    if not filename or not lldb_command:
+        print("Usage: solana_save_output <filename> <lldb command>")
+        print('Example: solana_save_output "/tmp/my out.txt" memory read 0x400000000')
+        return
+
+    # Capture stdout (for Python print() calls) and LLDB output
+    captured_stdout = io.StringIO()
+    old_stdout = sys.stdout
+    sys.stdout = captured_stdout
+
+    try:
+        ret = lldb.SBCommandReturnObject()
+        interpreter = debugger.GetCommandInterpreter()
+        interpreter.HandleCommand(lldb_command, ret)
+        lldb_output = ret.GetOutput() or ""
+        lldb_error = ret.GetError() or ""
+    finally:
+        sys.stdout = old_stdout
+
+    stdout_output = captured_stdout.getvalue()
+
+    # Combine all outputs
+    all_output = stdout_output + lldb_output + lldb_error
+
+    if not ret.Succeeded():
+        print("LLDB command failed.")
+        if lldb_error:
+            print(lldb_error, end="")
+        return
+
+    if not all_output:
+        print("No output captured.")
+        return
+
+    # Print to console
+    print(all_output, end="")
+
+    # Save to file
+    try:
+        with open(filename, 'w') as f:
+            f.write(all_output)
+    except OSError as e:
+        print(f"Failed to write to {filename}: {e}")
+        return
+
+    print(f"\n[Saved to: {filename}]")
+
+
+def __lldb_init_module(debugger, internal_dict):
+    debugger.HandleCommand(
+        'command script add -f solana_save_output.solana_save_output_command solana_save_output'
+    )
+    print("Loaded. Use: solana_save_output <filename> <lldb command>")


### PR DESCRIPTION
## The problem

When debugging Solana programs with LLDB, you don't know which program you're debugging until you step through code (at least until recently https://github.com/anza-xyz/sbpf/pull/80). Additionally, LLDB has no built-in way to save a single command's output to a file, and Python module path issues prevent `solana-lldb` from working out of the box on some Linux distributions.

## What's changed

Add `lldb/scripts/solana/solana_input_deserialize_abiv1.py` which deserializes the input buffer passed to Solana program entrypoints at runtime. The script reads memory from address 0x400000000 (default) and parses:
- Account metadata (dup_marker, pubkey, owner, lamports, rent_epoch, original_data_len, data length, flags)
- Account data (first 128 bytes with address for manual inspection)
- Instruction data
- Program ID
- Total input buffer size

Follows the deserialization logic from solana-sdk/program-entrypoint:
https://github.com/anza-xyz/solana-sdk/blob/0b0796150d3016e88b89a509db34dcf7e34afd3c/program-entrypoint/src/lib.rs#L464

The script can be invoked immediately after connecting via gdb-remote, allowing you to identify which program you're debugging before stepping through any code. With this information you can load the appropriate debug symbols by mapping the program_id to its corresponding .so or .so.debug file using `target modules add / load`.

Add `lldb/scripts/solana/solana_save_output.py` - a utility to save any LLDB command output to a file. This can also be combined with a named pipe (`mkfifo`) to stream command output to an external process, effectively allowing another tool to receive LLDB results in real time without needing a dedicated server mode.

Add `lldb/docs/solana/README_SOLANA_LLDB_PYTHON.md` documenting Python path fixes for Ubuntu 22.04/24.04.

```text
solana_input_deserialize_abiv1 usage:
  solana_input_deserialize_abiv1                          # default address
  solana_input_deserialize_abiv1 0x400000000              # custom address
  solana_input_deserialize_abiv1 0x400000000 10240        # custom max_permitted_data_increase

solana_save_output usage:
  solana_save_output /tmp/out.txt <lldb command>          # save command output to file
  solana_save_output /tmp/mem.txt memory read 0x400000000 -c 100
  solana_save_output /tmp/regs.txt register read
  solana_save_output /tmp/bt.txt bt

Example output:
  (lldb) gdb-remote 127.0.0.1:1212
  (lldb) solana_input_deserialize_abiv1
  Deserializing at 0x400000000 (max_permitted_data_increase=10240)...
  ============================================================
  Accounts: 1
  ------------------------------------------------------------
    [0] @ 0x400000008
        pubkey: 6CSmiViMaAguKgxNVwU8TWMPViQbtL5KKoFrDwWwtYNR
        owner: BPFLoader2111111111111111111111111111111111
        lamports: 2828488320 (2.828488320 SOL)
        rent_epoch: 18446744073709551615
        dup_marker: 0xff, signer: False, writable: True, executable: True
        original_data_len: 0, data_len: 406264
        data @ 0x400000060: x/406264b 0x400000060
        7f 45 4c 46 02 01 01 00 00 00 00 00 00 00 00 00
        03 00 07 01 01 00 00 00 a0 68 01 00 00 00 00 00
        40 00 00 00 00 00 00 00 b8 30 06 00 00 00 00 00
        01 00 00 00 40 00 38 00 04 00 40 00 09 00 08 00
        01 00 00 00 05 00 00 00 20 01 00 00 00 00 00 00
        20 01 00 00 00 00 00 00 20 01 00 00 00 00 00 00
        88 47 05 00 00 00 00 00 88 47 05 00 00 00 00 00
        00 10 00 00 00 00 00 00 01 00 00 00 06 00 00 00
        ... (406136 more bytes)
  ------------------------------------------------------------
  Instruction data (8 bytes @ 0x400065b68): x/8b 0x400065b68
        4c ad 06 5f b5 5d 53 ce
  ------------------------------------------------------------
  Program ID: ESHnYJDZfq2giPQeqmhqZucvPHiSVNjPoZxBV6dKKbHA (address: 0x400065b70)
  ------------------------------------------------------------
  Total input buffer size: 416656 bytes (0x65b90)
  ============================================================
```

Updated `solana-lldb` to auto-load both scripts on debugger startup.

