### PR TITLE
draft: implement .include directive in sbpf compiler

### DIFF
--- a/llvm/test/MC/SBF/sbf-include-basic.s
+++ b/llvm/test/MC/SBF/sbf-include-basic.s
@@ -1,0 +1,22 @@
+# RUN: llvm-mc %s -triple=sbf-solana-solana -filetype=obj -I %p -o %t.o
+# RUN: llvm-objdump -d %t.o | FileCheck %s --check-prefix=CHECK-OBJ
+
+# Test basic .include directive functionality for SBF
+
+.include "sbf-include-helper.s"
+
+.text
+.globl entrypoint
+entrypoint:
+  call custom_log
+  exit
+
+# CHECK-OBJ: lddw
+# CHECK-OBJ: r1
+# CHECK-OBJ: lddw
+# CHECK-OBJ: r2, 0xe
+# CHECK-OBJ: call
+# CHECK-OBJ: exit
+# CHECK-OBJ: <entrypoint>:
+# CHECK-OBJ: call
+# CHECK-OBJ: exit

--- a/llvm/test/MC/SBF/sbf-include-globl-helper.s
+++ b/llvm/test/MC/SBF/sbf-include-globl-helper.s
@@ -1,0 +1,9 @@
+# Helper file for sbf-include-no-globl.s
+# This file contains a .globl directive which should produce an error
+# when included
+
+.text
+.globl helper_fn
+helper_fn:
+  mov64 r0, 0
+  exit

--- a/llvm/test/MC/SBF/sbf-include-helper.s
+++ b/llvm/test/MC/SBF/sbf-include-helper.s
@@ -1,0 +1,11 @@
+# Helper file for sbf-include-basic.s
+# This file defines a simple function that can be included
+
+custom_log:
+    lddw r1, message
+    lddw r2, 14
+    call sol_log_
+    exit
+
+.rodata
+    message: .ascii "Hello, Solana!"

--- a/llvm/test/MC/SBF/sbf-include-missing.s
+++ b/llvm/test/MC/SBF/sbf-include-missing.s
@@ -1,0 +1,15 @@
+# RUN: not llvm-mc %s -triple=sbf-solana-solana -filetype=obj -I %p 2>&1 \
+# RUN:     | FileCheck %s --check-prefix=CHECK
+
+# Test that including a non-existent file produces an error
+
+# CHECK: error:
+# CHECK: Could not find include file
+# CHECK: nonexistent_file.s
+
+.include "nonexistent_file.s"
+
+.text
+.globl entrypoint
+entrypoint:
+  exit

--- a/llvm/test/MC/SBF/sbf-include-nested-inner.s
+++ b/llvm/test/MC/SBF/sbf-include-nested-inner.s
@@ -1,0 +1,11 @@
+# Inner file for nested include test
+# This file is included by sbf-include-nested-middle.s
+
+custom_log:
+    lddw r1, message
+    lddw r2, 7
+    call sol_log_
+    exit
+
+.rodata
+    message: .ascii "Nested!"

--- a/llvm/test/MC/SBF/sbf-include-nested-middle.s
+++ b/llvm/test/MC/SBF/sbf-include-nested-middle.s
@@ -1,0 +1,4 @@
+# Middle file for nested include test
+# This file is included by sbf-include-nested.s and includes the inner file
+
+.include "sbf-include-nested-inner.s"

--- a/llvm/test/MC/SBF/sbf-include-nested.s
+++ b/llvm/test/MC/SBF/sbf-include-nested.s
@@ -1,0 +1,22 @@
+# RUN: llvm-mc %s -triple=sbf-solana-solana -filetype=obj -I %p -o %t.o
+# RUN: llvm-objdump -d %t.o | FileCheck %s --check-prefix=CHECK-OBJ
+
+# Test nested .include directive functionality for SBF
+
+.include "sbf-include-nested-middle.s"
+
+.text
+.globl entrypoint
+entrypoint:
+  call custom_log
+  exit
+
+# CHECK-OBJ: lddw
+# CHECK-OBJ: r1
+# CHECK-OBJ: lddw
+# CHECK-OBJ: r2, 0x7
+# CHECK-OBJ: call
+# CHECK-OBJ: exit
+# CHECK-OBJ: <entrypoint>:
+# CHECK-OBJ: call
+# CHECK-OBJ: exit

--- a/llvm/test/MC/SBF/sbf-include-no-globl.s
+++ b/llvm/test/MC/SBF/sbf-include-no-globl.s
@@ -1,0 +1,16 @@
+# RUN: not llvm-mc %s -triple=sbf-solana-solana -filetype=obj -I %p 2>&1 \
+# RUN:     | FileCheck %s --check-prefix=CHECK
+
+# Test that .globl in an included file produces an error for SBF
+
+# CHECK: error:
+# CHECK: .globl 'helper_fn' is not allowed in included files
+# CHECK: Only the main entrypoint file should declare .globl symbols
+
+.include "sbf-include-globl-helper.s"
+
+.text
+.globl entrypoint
+entrypoint:
+  call helper_fn
+  exit


### PR DESCRIPTION
@blueshift-gg is implementing the .include directive for sBPF here - https://github.com/blueshift-gg/sbpf/pull/109. propsing this change for backwards compatibility.

Vibe-coded this implementation and am posting this as a draft for now. Will make a proper contribution once I inspect the diff well and understand what actually needs to be shipped. 

Any feedback on this change and pointers for this would be welcome.