### PR TITLE
[SOL] Add -sbf-stack-size option to configure the stack frame size

### DIFF
--- a/llvm/lib/Target/SBF/SBFISelLowering.cpp
+++ b/llvm/lib/Target/SBF/SBFISelLowering.cpp
@@ -24,10 +24,15 @@
 #include "llvm/IR/DiagnosticInfo.h"
 #include "llvm/IR/DiagnosticPrinter.h"
 #include "llvm/Support/ErrorHandling.h"
+#include "llvm/Support/CommandLine.h"
 #include "llvm/Support/raw_ostream.h"
 using namespace llvm;
 
 #define DEBUG_TYPE "sbf-lower"
+
+static cl::opt<unsigned>
+    SBFStackSize("sbf-stack-size", cl::init(4096),
+                 cl::desc("Specify the SBF stack frame size in bytes"));
 
 static void fail(const SDLoc &DL, SelectionDAG &DAG, const Twine &Msg) {
   MachineFunction &MF = DAG.getMachineFunction();
@@ -171,7 +176,7 @@ SBFTargetLowering::SBFTargetLowering(const TargetMachine &TM,
   // CPU/Feature control
   HasAlu32 = STI.getHasAlu32();
   HasJmp32 = STI.getHasJmp32();
-  SBFRegisterInfo::FrameLength = 4096;
+  SBFRegisterInfo::FrameLength = SBFStackSize;
 }
 
 bool SBFTargetLowering::allowsMisalignedMemoryAccesses(

--- a/llvm/lib/Target/SBF/SBFRegisterInfo.cpp
+++ b/llvm/lib/Target/SBF/SBFRegisterInfo.cpp
@@ -72,7 +72,8 @@ static void warnSize(const int Offset, MachineFunction &MF,
     dbgs() << " Function " << MF.getFunction().getName()
            << " overflows the maximum allowed frame space by accessing "
            << "an offset " << Overflow << " bytes greater than the "
-           << "maximum of 4096. Please, minimize large stack variables. "
+           << "maximum of " << SBFRegisterInfo::FrameLength
+           << ". Please, minimize large stack variables. "
            << "Estimated function frame size: " << StackSize << " bytes."
            << " Exceeding the maximum stack offset may cause "
               "undefined behavior during execution.\n\n";

--- a/llvm/test/CodeGen/SBF/stack-size.ll
+++ b/llvm/test/CodeGen/SBF/stack-size.ll
@@ -1,0 +1,41 @@
+; RUN: llc -march=sbf < %s 2>&1 >/dev/null | FileCheck %s --check-prefix=DEFAULT
+; RUN: llc -march=sbf -sbf-stack-size=8192 < %s 2>&1 >/dev/null | FileCheck %s --check-prefix=BUMPED --allow-empty
+; RUN: llc -march=sbf -mcpu=v3 < %s 2>&1 >/dev/null | FileCheck %s --check-prefix=DEFAULT
+; RUN: llc -march=sbf -mcpu=v3 -sbf-stack-size=8192 < %s 2>&1 >/dev/null | FileCheck %s --check-prefix=BUMPED --allow-empty
+;
+; Source:
+;   extern void doit(void *);
+;   void warn(void) {
+;       char buf[5000];
+;       long x;
+;       doit(&x);
+;       doit(buf);
+;   }
+; Compilation:
+;   clang -target sbf -S -emit-llvm -g -O2 warn_stack.c
+
+declare void @doit(ptr)
+
+; DEFAULT: Error: warn_stack.c
+; DEFAULT: Please, minimize large stack variables
+; DEFAULT: Exceeding the maximum stack offset may cause undefined behavior during execution.
+; BUMPED-NOT: Please, minimize large stack variables
+define void @warn() !dbg !5 {
+  %buf = alloca [5000 x i8], align 1
+  %x = alloca i64, align 8
+  call void @doit(ptr nonnull %x), !dbg !7
+  call void @doit(ptr nonnull %buf), !dbg !7
+  ret void, !dbg !7
+}
+
+!llvm.dbg.cu = !{!0}
+!llvm.module.flags = !{!3, !4}
+
+!0 = distinct !DICompileUnit(language: DW_LANG_C99, file: !1, producer: "clang", isOptimized: true, runtimeVersion: 0, emissionKind: FullDebug, enums: !2)
+!1 = !DIFile(filename: "warn_stack.c", directory: "/")
+!2 = !{}
+!3 = !{i32 2, !"Dwarf Version", i32 4}
+!4 = !{i32 2, !"Debug Info Version", i32 3}
+!5 = distinct !DISubprogram(name: "warn", scope: !1, file: !1, line: 2, type: !6, isLocal: false, isDefinition: true, scopeLine: 2, flags: DIFlagPrototyped, isOptimized: true, unit: !0)
+!6 = !DISubroutineType(types: !2)
+!7 = !DILocation(line: 5, column: 5, scope: !5)


### PR DESCRIPTION
**The problem**

An approach to solving: https://github.com/anza-xyz/llvm-project/issues/193

**What's changed**

Add a cl::opt to allow specifying the SBF stack frame size at compile time, consistent with upstream BPF's -bpf-stack-size flag. Defaults to 4096. Usage: -C llvm-args=-sbf-stack-size=N. Intentionally renamed so that it won't collide with upstream's name.

The `cargo-build-sbf` tool can then take advantage with adding an option like so: https://github.com/procdump/agave/commit/7b4bab08e6a9818fb3fbc531d5f65ca5e9d9fb02