### PR TITLE
[SOL] Fix DW_OP_fbreg offsets for SBPFv3 stack variables

### DIFF
--- a/llvm/lib/Target/SBF/SBFFrameLowering.cpp
+++ b/llvm/lib/Target/SBF/SBFFrameLowering.cpp
@@ -11,6 +11,8 @@
 //===----------------------------------------------------------------------===//
 
 #include "SBFFrameLowering.h"
+#include "SBFFunctionInfo.h"
+#include "SBFRegisterInfo.h"
 #include "SBFSubtarget.h"
 #include "llvm/CodeGen/MachineFrameInfo.h"
 #include "llvm/CodeGen/MachineFunction.h"
@@ -53,4 +55,39 @@ void SBFFrameLowering::determineCalleeSaves(MachineFunction &MF,
   SavedRegs.reset(SBF::R7);
   SavedRegs.reset(SBF::R8);
   SavedRegs.reset(SBF::R9);
+}
+
+StackOffset
+SBFFrameLowering::getFrameIndexReference(const MachineFunction &MF, int FI,
+                                         Register &FrameReg) const {
+  const MachineFrameInfo &MFI = MF.getFrameInfo();
+  const SBFSubtarget &Subtarget = MF.getSubtarget<SBFSubtarget>();
+  const SBFFunctionInfo *SBFFuncInfo = MF.getInfo<SBFFunctionInfo>();
+
+  FrameReg = SBF::R10;
+
+  // For SBPFv3+ the runtime auto-bumps R10 by FrameLength on each call so
+  // that R10 ends up at the high end of the callee's frame slot.
+  // SBFRegisterInfo::resolveInternalFrameIndex therefore emits stores as
+  // `r10 + (Offset_FI - FrameLength)` (a negative displacement). Mirror that
+  // adjustment in the DWARF location so DW_OP_fbreg + N names the same byte
+  // the store wrote, instead of the default `Offset_FI + StackSize` which
+  // resolves to an address in the next, uninitialized frame slot.
+  //
+  // The override fires only for v3+ (HasNoStackGaps && !HasDynamicFrames):
+  //   - v1/v2 have HasDynamicFrames=true, so emitPrologue inserts an
+  //     `add r10, -StackSize`, making R10 the low end of the frame; the
+  //     default formula matches that.
+  //   - v0 has HasNoStackGaps=false and short-circuits to the default branch
+  //     below; its (gapped) layout is intentionally left untouched here.
+  // Stack-passed argument frame indices (containsFrameIndex) also use the
+  // default — their bytes live in the caller's frame, which needs a separate
+  // adjustment.
+  if (Subtarget.getHasNoStackGaps() && !Subtarget.getHasDynamicFrames() &&
+      !SBFFuncInfo->containsFrameIndex(FI)) {
+    return StackOffset::getFixed(MFI.getObjectOffset(FI) -
+                                 static_cast<int>(SBFRegisterInfo::FrameLength));
+  }
+
+  return TargetFrameLowering::getFrameIndexReference(MF, FI, FrameReg);
 }

--- a/llvm/lib/Target/SBF/SBFFrameLowering.h
+++ b/llvm/lib/Target/SBF/SBFFrameLowering.h
@@ -33,6 +33,9 @@ public:
   void determineCalleeSaves(MachineFunction &MF, BitVector &SavedRegs,
                             RegScavenger *RS) const override;
 
+  StackOffset getFrameIndexReference(const MachineFunction &MF, int FI,
+                                     Register &FrameReg) const override;
+
   MachineBasicBlock::iterator
   eliminateCallFramePseudoInstr(MachineFunction &MF, MachineBasicBlock &MBB,
                                 MachineBasicBlock::iterator MI) const override {


### PR DESCRIPTION
On SBPFv3, `resolveInternalFrameIndex` emits `r10 + (Offset_FI - FrameLength)` (negative), but the default `getFrameIndexReference` returns `Offset_FI + StackSize`, so `DW_OP_fbreg + N` resolves into the wrong frame slot and locals show as `0x0` in lldb. Override `SBFFrameLowering::getFrameIndexReference` to mirror the instruction-side adjustment for SBPFv3 (gated on `getHasNoStackGaps() && !getHasDynamicFrames()`); skip `containsFrameIndex(FI)`. It is DWARF-only related and instruction encoding is unchanged.
