### PR TITLE
[SOL] Fix SBF header

### DIFF
--- a/llvm/lib/MC/ELFObjectWriter.cpp
+++ b/llvm/lib/MC/ELFObjectWriter.cpp
@@ -302,7 +302,9 @@ void ELFWriter::writeHeader() {
   W.OS << char(ELF::EV_CURRENT);        // e_ident[EI_VERSION]
   // e_ident[EI_OSABI]
   uint8_t OSABI = OWriter.TargetObjectWriter->getOSABI();
-  W.OS << char(OSABI == ELF::ELFOSABI_NONE && OWriter.seenGnuAbi()
+  uint16_t e_machine = OWriter.TargetObjectWriter->getEMachine();
+  W.OS << char(OSABI == ELF::ELFOSABI_NONE && OWriter.seenGnuAbi() &&
+                       e_machine != ELF::EM_BPF && e_machine != ELF::EM_SBF
                    ? int(ELF::ELFOSABI_GNU)
                    : OSABI);
   // e_ident[EI_ABIVERSION]

--- a/llvm/test/CodeGen/SBF/header_abi.ll
+++ b/llvm/test/CodeGen/SBF/header_abi.ll
@@ -1,0 +1,31 @@
+; RUN: llc -march=sbf -filetype=obj -o %t.el < %s
+; RUN: llvm-readelf --headers %t.el | FileCheck %s
+; RUN: llc -march=sbf -mcpu=v1 -filetype=obj -o %t.el < %s
+; RUN: llvm-readelf --headers %t.el | FileCheck %s
+; RUN: llc -march=sbf -mcpu=v2 -filetype=obj -o %t.el < %s
+; RUN: llvm-readelf --headers %t.el | FileCheck %s
+; RUN: llc -march=sbf -mcpu=v3 -filetype=obj -o %t.el < %s
+; RUN: llvm-readelf --headers %t.el | FileCheck %s
+
+; CHECK: OS/ABI:                            UNIX - System V
+
+source_filename = "repro.6f693e153dbaee6f-cgu.0"
+target datalayout = "e-m:e-p:64:64-i64:64-n32:64-S128"
+target triple = "sbf"
+
+@_ZN5repro7_RODATA17h37262c379f67649dE = hidden constant [1 x i8] zeroinitializer, align 1
+@llvm.used = appending global [1 x ptr] [ptr @_ZN5repro7_RODATA17h37262c379f67649dE], section "llvm.metadata"
+
+; Function Attrs: mustprogress nofree norecurse nosync nounwind willreturn memory(none)
+define noundef i64 @entrypoint(ptr nocapture noundef readnone %_input) unnamed_addr #0 {
+start:
+  ret i64 0
+}
+
+attributes #0 = { mustprogress nofree norecurse nosync nounwind willreturn memory(none) "target-cpu"="generic" }
+
+!llvm.module.flags = !{!0}
+!llvm.ident = !{!1}
+
+!0 = !{i32 8, !"PIC Level", i32 2}
+!1 = !{!"rustc version 1.89.0-dev"}


### PR DESCRIPTION
This PR prevents the OS/ABI conversion when SHF_GNU_RETAIN is used.

Please, ignore the failing test. It is only supposed to display a greeter in the PR. I'll see if I can remove it later.