### PR TITLE
[SOL] Fix integer argument extension for FPOWI libcall

### DIFF
--- a/llvm/lib/CodeGen/SelectionDAG/LegalizeFloatTypes.cpp
+++ b/llvm/lib/CodeGen/SelectionDAG/LegalizeFloatTypes.cpp
@@ -770,6 +770,7 @@ SDValue DAGTypeLegalizer::SoftenFloatRes_ExpOp(SDNode *N) {
   EVT OpsVT[2] = { N->getOperand(0 + Offset).getValueType(),
                    N->getOperand(1 + Offset).getValueType() };
   CallOptions.setTypeListBeforeSoften(OpsVT, N->getValueType(0));
+  CallOptions.setIsSigned();
   std::pair<SDValue, SDValue> Tmp = TLI.makeLibCall(DAG, LC, NVT, Ops,
                                                     CallOptions, SDLoc(N),
                                                     Chain);

--- a/llvm/lib/Target/SBF/SBFISelLowering.cpp
+++ b/llvm/lib/Target/SBF/SBFISelLowering.cpp
@@ -618,11 +618,6 @@ SDValue SBFTargetLowering::LowerCall(TargetLowering::CallLoweringInfo &CLI,
                          InVals);
 }
 
-bool SBFTargetLowering::shouldSignExtendTypeInLibCall(Type* Ty,
-                                                      bool IsSigned) const {
-  return IsSigned || Ty->isIntegerTy(32);
-}
-
 bool SBFTargetLowering::CanLowerReturn(
     CallingConv::ID CallConv, MachineFunction &MF, bool IsVarArg,
     const SmallVectorImpl<ISD::OutputArg> &Outs, LLVMContext &Context,

--- a/llvm/lib/Target/SBF/SBFISelLowering.h
+++ b/llvm/lib/Target/SBF/SBFISelLowering.h
@@ -98,9 +98,6 @@ private:
   SDValue LowerCall(TargetLowering::CallLoweringInfo &CLI,
                     SmallVectorImpl<SDValue> &InVals) const override;
 
-  /// Returns true if arguments should be sign-extended in lib calls.
-  bool shouldSignExtendTypeInLibCall(Type* Ty, bool IsSigned) const override;
-
   // Lower incoming arguments, copy physregs into vregs
   SDValue LowerFormalArguments(SDValue Chain, CallingConv::ID CallConv,
                                bool IsVarArg,

--- a/llvm/test/CodeGen/SBF/f64-intrinsics.ll
+++ b/llvm/test/CodeGen/SBF/f64-intrinsics.ll
@@ -22,3 +22,34 @@ define double @powi_f64(double %a, i32 %b) nounwind {
   ret double %1
 }
 
+define double @uitofp64(i32 %arg) nounwind {
+; CHECK32-LABEL: uitofp64:
+; CHECK32:       # %bb.0:
+; CHECK32-NEXT:    call __floatunsidf
+; CHECK32-NEXT:    exit
+;
+; CHECK64-LABEL: uitofp64:
+; CHECK64:       # %bb.0:
+; CHECK64-NEXT:    lsh64 r1, 32
+; CHECK64-NEXT:    rsh64 r1, 32
+; CHECK64-NEXT:    call __floatunsidf
+; CHECK64-NEXT:    exit
+  %1 = uitofp i32 %arg to double
+  ret double %1
+}
+
+define double @sitofp64(i32 %arg) nounwind {
+; CHECK32-LABEL: sitofp64:
+; CHECK32:       # %bb.0:
+; CHECK32-NEXT:    call __floatsidf
+; CHECK32-NEXT:    exit
+;
+; CHECK64-LABEL: sitofp64:
+; CHECK64:       # %bb.0:
+; CHECK64-NEXT:    lsh64 r1, 32
+; CHECK64-NEXT:    arsh64 r1, 32
+; CHECK64-NEXT:    call __floatsidf
+; CHECK64-NEXT:    exit
+  %1 = sitofp i32 %arg to double
+  ret double %1
+}

--- a/llvm/test/CodeGen/SBF/f64-intrinsics.ll
+++ b/llvm/test/CodeGen/SBF/f64-intrinsics.ll
@@ -1,5 +1,6 @@
 ; RUN: llc -march=sbf -mattr=+alu32 < %s | FileCheck -check-prefix=CHECK32 %s
 ; RUN: llc -march=sbf < %s | FileCheck -check-prefix=CHECK64 %s
+; RUN: llc -march=sbf -mcpu=v3 -mattr=+alu32 < %s | FileCheck -check-prefix=CHECK32 %s
 
 ; TODO: Add much more coverage. Currently this a sign extension regression
 ; test (SBFTargetLowering::shouldSignExtendTypeInLibCall).


### PR DESCRIPTION
The blanket sign extension whenever an integer argument is 32 bytes is wrong for some other libcalls such as the u32->f64 conversion. The libcall for that expects to get upper 32 bits to be zeroed. SBF code we have right now would sign extend that argument despite it being an unsigned integer anyway.

Instead I applied a more targetted fix for FPOWI/LDEXP that marks these instructions as dealing with signed integers so that the `shouldSignExtend...` function gets the correct `IsSigned` flag in the first place for these libcalls.

Will explore submitting this after cleaning it up upstream as well.