### PR TITLE
[SOL] Fix warning overflow

### DIFF
--- a/llvm/lib/Target/SBF/SBFRegisterInfo.cpp
+++ b/llvm/lib/Target/SBF/SBFRegisterInfo.cpp
@@ -42,17 +42,17 @@ BitVector SBFRegisterInfo::getReservedRegs(const MachineFunction &MF) const {
   return Reserved;
 }
 
-static void warnSize(const int Offset, MachineFunction &MF,
+static void warnSize(const int RequestedOffset, MachineFunction &MF,
                      const DebugLoc & DL, const bool StackGrowsUp,
-                     const int64_t ObjectSize) {
+                     const int ObjectOffset, const int ObjectSize) {
 
   static Function *OldMF = nullptr;
   const int MaxOffset = -1 * SBFRegisterInfo::FrameLength;
   bool ShouldWarn = false;
 
-  if (StackGrowsUp && Offset + ObjectSize > 0) {
+  if (StackGrowsUp && ObjectOffset + ObjectSize > 0) {
     ShouldWarn = true;
-  } else if (!StackGrowsUp && Offset < MaxOffset) {
+  } else if (!StackGrowsUp && RequestedOffset < MaxOffset) {
     ShouldWarn = true;
   }
 
@@ -154,13 +154,13 @@ int SBFRegisterInfo::resolveInternalFrameIndex(llvm::MachineFunction &MF,
                                                const DebugLoc &DL) const {
   const MachineFrameInfo &MFI = MF.getFrameInfo();
   const SBFFunctionInfo *SBFFuncInfo = MF.getInfo<SBFFunctionInfo>();
-  int Offset = MFI.getObjectOffset(FI);
+  int ObjectOffset = MFI.getObjectOffset(FI);
   const SBFSubtarget & SubTarget = MF.getSubtarget<SBFSubtarget>();
   const uint64_t StackSize = MFI.getStackSize();
 
   if (!SubTarget.getHasNoStackGaps() && SBFFuncInfo->containsFrameIndex(FI)) {
-    Offset = SBFRegisterInfo::FrameLength - Offset;
-    if (static_cast<uint64_t>(Offset) < StackSize) {
+    ObjectOffset = SBFRegisterInfo::FrameLength - ObjectOffset;
+    if (static_cast<uint64_t>(ObjectOffset) < StackSize) {
       dbgs() << "Error: A function call in method "
              << MF.getFunction().getName()
              << " overwrites values in the frame. Please, decrease stack usage "
@@ -168,7 +168,7 @@ int SBFRegisterInfo::resolveInternalFrameIndex(llvm::MachineFunction &MF,
              << "The function call may cause undefined behavior "
                 "during execution.\n\n";
     }
-    return -Offset;
+    return -ObjectOffset;
   }
 
   if (SubTarget.getHasNoStackGaps() && SBFFuncInfo->containsFrameIndex(FI)) {
@@ -177,26 +177,30 @@ int SBFRegisterInfo::resolveInternalFrameIndex(llvm::MachineFunction &MF,
     // not the callee.
     // PS: We have incremented it in fn LowerCall at SBFISelLowering.
     if (SubTarget.stackGrowsUp())
-      return -(static_cast<int>(MFI.getObjectSize(FI)) + Offset);
+      return -(static_cast<int>(MFI.getObjectSize(FI)) + ObjectOffset);
 
-    return -Offset;
+    return -ObjectOffset;
   }
 
-  Offset += Imm.value_or(0);
 
-  int64_t ObjectSize = MFI.getObjectSize(FI);
+  int ElementOffset = ObjectOffset + Imm.value_or(0);
+
+  int ObjectSize = static_cast<int>(MFI.getObjectSize(FI));
   if (SubTarget.getHasNoStackGaps()) {
     if (SubTarget.getHasDynamicFrames())
-      return Offset + static_cast<int>(StackSize);
+      return ElementOffset + static_cast<int>(StackSize);
 
-    const int V3Offset = Offset - static_cast<int>(FrameLength);
-    warnSize(V3Offset, MF, DL, SubTarget.stackGrowsUp(), ObjectSize);
-    return V3Offset;
+    const int V3ElementOffset = ElementOffset - static_cast<int>(FrameLength);
+    const int V3ObjectOffset = ObjectOffset - static_cast<int>(FrameLength);
+    warnSize(V3ElementOffset, MF, DL, SubTarget.stackGrowsUp(), V3ObjectOffset,
+             ObjectSize);
+    return V3ElementOffset;
   }
 
   // Only sBPFv0 will reach this stage, because it has stack gaps.
-  warnSize(Offset, MF, DL, SubTarget.stackGrowsUp(), ObjectSize);
-  return Offset;
+  warnSize(ElementOffset, MF, DL, SubTarget.stackGrowsUp(), ObjectOffset,
+           ObjectSize);
+  return ElementOffset;
 }
 
 Register SBFRegisterInfo::getFrameRegister(const MachineFunction &MF) const {

--- a/llvm/test/CodeGen/SBF/v3_stack_warnings.ll
+++ b/llvm/test/CodeGen/SBF/v3_stack_warnings.ll
@@ -45,3 +45,26 @@ define i64 @caller(i64 %a, i64 %b, i64 %c, i64 %d, i64 %e) {
     %res = call i64 @callee(i64 %a, i64 %b, i64 %c, i64 %d, i64 %e, i64 %f, i64 %g)
     ret i64 %res
 }
+
+; CHECK-NOT: Error: Function stack_overflow_wrong
+define i64 @stack_overflow_wrong(i64 %a) {
+start:
+  %0 = alloca [100 x i8], align 8
+  %1 = alloca [100 x i8], align 8
+  %2 = alloca [100 x i8], align 8
+  %buffer = alloca [3700 x i8], align 1
+; The offset for this getelementptr is less than the object size.
+  %b1 = getelementptr inbounds nuw i8, ptr %buffer, i64 500
+  %b2 = getelementptr inbounds nuw i8, ptr %0, i64 10
+  %b3 = getelementptr inbounds nuw i8, ptr %1, i64 10
+  %b4 = getelementptr inbounds nuw i8, ptr %2, i64 10
+  %b = load i64, ptr %b1, align 8
+  %c1 = load i64, ptr %b2, align 8
+  %c2 = load i64, ptr %b3, align 8
+  %c3 = load i64, ptr %b4, align 8
+  %c = add i64 %b, %a
+  %d = add i64 %c, %c1
+  %e = add i64 %c2, %d
+  %f = add i64 %c3, %e
+  ret i64 %f
+}


### PR DESCRIPTION
**Problem**

The overflow warning for SBPFv3 is incorrect in that it is accounting for the element offset plus the object size to decide when to warn. The calculation must, instead, use the object size plus the object offset to know if the whole object overflows the allocated stack size.

**Solution**

Rename some variable to make clear what they represent, and use the same data type everywhere.