### PR TITLE
[SOL] Fix mig command

### DIFF
--- a/lldb/tools/debugserver/source/CMakeLists.txt
+++ b/lldb/tools/debugserver/source/CMakeLists.txt
@@ -181,7 +181,7 @@ endif()
 separate_arguments(MIG_ARCH_FLAGS_SEPARTED NATIVE_COMMAND "${MIG_ARCH_FLAGS}")
 
 add_custom_command(OUTPUT ${generated_mach_interfaces}
-  VERBATIM COMMAND mig ${MIG_ARCH_FLAGS_SEPARTED} -isysroot ${CMAKE_OSX_SYSROOT} ${CMAKE_CURRENT_SOURCE_DIR}/MacOSX/dbgnub-mig.defs
+  VERBATIM COMMAND mig ${MIG_ARCH_FLAGS_SEPARTED} -header ${CMAKE_CURRENT_BINARY_DIR}/mach_exc.h -server ${CMAKE_CURRENT_BINARY_DIR}/mach_excServer.c -user ${CMAKE_CURRENT_BINARY_DIR}/mach_excUser.c ${CMAKE_CURRENT_SOURCE_DIR}/MacOSX/dbgnub-mig.defs
   DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/MacOSX/dbgnub-mig.defs
   )
 


### PR DESCRIPTION
The CI for v1.46.1 is failing in https://github.com/anza-xyz/platform-tools/pull/123.

I'm cherry-picking the fix from https://github.com/anza-xyz/llvm-project/pull/169 to make it work.

PS: This is the same thing as #211, but for LLVM 18.