### PR TITLE
[SOL] Fix version detection in call lowering

### DIFF
--- a/llvm/lib/Target/SBF/SBFISelLowering.cpp
+++ b/llvm/lib/Target/SBF/SBFISelLowering.cpp
@@ -555,7 +555,7 @@ SDValue SBFTargetLowering::LowerCall(TargetLowering::CallLoweringInfo &CLI,
 
   if (!MemOpChain.empty()) {
     Chain = DAG.getNode(ISD::TokenFactor, CLI.DL, MVT::Other, MemOpChain);
-    if (!Subtarget->getHasDynamicFrames()) {
+    if (!Subtarget->getHasNoStackGaps()) {
       // Pass the current stack frame pointer via SBF::R5, gluing the
       // instruction to instructions passing the first 4 arguments in
       // registers below.
@@ -596,7 +596,7 @@ SDValue SBFTargetLowering::LowerCall(TargetLowering::CallLoweringInfo &CLI,
   for (auto &Reg : RegsToPass)
     Ops.push_back(DAG.getRegister(Reg.first, Reg.second.getValueType()));
 
-  if (!MemOpChain.empty() && !Subtarget->getHasDynamicFrames()) {
+  if (!MemOpChain.empty() && !Subtarget->getHasNoStackGaps()) {
     Ops.push_back(DAG.getRegister(SBF::R5, MVT::i64));
   }
 

--- a/llvm/test/CodeGen/SBF/many_args_new_conv.ll
+++ b/llvm/test/CodeGen/SBF/many_args_new_conv.ll
@@ -1,7 +1,8 @@
 ; RUN: llc -march=sbf -mcpu=v1 < %s | FileCheck %s
 ; RUN: llc -mtriple=sbpfv1-solana-solana < %s | FileCheck %s
 ; RUN: llc -march=sbf -mcpu=v1 -mattr=+mem-encoding < %s | FileCheck %s
-; RUN: llc -march=sbf -mcpu=v3 < %s | FileCheck --check-prefix=CHECK-V3 %s
+; RUN: llc -march=sbf -mcpu=v3 < %s | FileCheck --check-prefixes=CHECK-V3,CHECK-V3-OPT %s
+; RUN: llc -O0 -march=sbf -mcpu=v3 < %s | FileCheck --check-prefixes=CHECK-V3,CHECK-V3-OPTNONE %s
 
 ; Function Attrs: nounwind uwtable
 define i32 @caller_no_alloca(i32 %a, i32 %b, i32 %c) #0 {
@@ -23,6 +24,8 @@ entry:
 ; CHECK-V3: stdw [r10 + 16], 50
 ; CHECK-V3: stdw [r10 + 8], 4
 ; CHECK-V3: stdw [r10 + 0], 3
+; CHECK-V3-OPT-NOT: mov64 r5, r10
+; CHECK-V3-OPTNONE: mov64 r5, r10
 
 ; CHECK: mov64 r4, 1
 ; CHECK: mov64 r5, 2
@@ -65,6 +68,8 @@ define i32 @caller_alloca(i32 %a, i32 %b, i32 %c) #0 {
 ; CHECK-V3: stdw [r10 + 8], 4
 ; Offset in the callee: -frame_size + 0
 ; CHECK-V3: stdw [r10 + 0], 3
+; CHECK-V3-OPT-NOT: mov64 r5, r10
+; CHECK-V3-OPTNONE: mov64 r5, r10
 
 ; CHECK: mov64 r4, 1
 ; CHECK: mov64 r5, 2
@@ -97,11 +102,11 @@ define i32 @callee_alloca(i32 %a, i32 %b, i32 %c, i32 %d, i32 %e, i32 %f, i32 %p
 ; Loading allocated i32
 ; CHECK: ldxw r0, [r10 + 24]
 
-; CHECK-V3: ldxw r2, [r10 - 4096]
-; CHECK-V3: ldxw r2, [r10 - 4088]
-; CHECK-V3: ldxw r2, [r10 - 4080]
-; CHECK-V3: ldxw r2, [r10 - 4072]
-; CHECK-V3: ldxw r2, [r10 - 4064]
+; CHECK-V3-OPT: ldxw r2, [r10 - 4096]
+; CHECK-V3-OPT: ldxw r2, [r10 - 4088]
+; CHECK-V3-OPT: ldxw r2, [r10 - 4080]
+; CHECK-V3-OPT: ldxw r2, [r10 - 4072]
+; CHECK-V3-OPT: ldxw r2, [r10 - 4064]
 ; Loading allocated i32
 ; CHECK-V3: ldxw r0, [r10 - 4056]
 
@@ -138,11 +143,11 @@ define i32 @callee_no_alloca(i32 %a, i32 %b, i32 %c, i32 %d, i32 %e, i32 %f, i32
 ; CHECK: ldxw r1, [r10 + 24]
 
 ; Loading arguments
-; CHECK-V3: ldxw r1, [r10 - 4096]
-; CHECK-V3: ldxw r1, [r10 - 4088]
-; CHECK-V3: ldxw r1, [r10 - 4080]
-; CHECK-V3: ldxw r1, [r10 - 4072]
-; CHECK-V3: ldxw r1, [r10 - 4064]
+; CHECK-V3-OPT: ldxw r1, [r10 - 4096]
+; CHECK-V3-OPT: ldxw r1, [r10 - 4088]
+; CHECK-V3-OPT: ldxw r1, [r10 - 4080]
+; CHECK-V3-OPT: ldxw r1, [r10 - 4072]
+; CHECK-V3-OPT: ldxw r1, [r10 - 4064]
 
 ; CHECK-NOT: add64 r10, 64
 entry:

--- a/llvm/test/CodeGen/SBF/many_args_new_conv.ll
+++ b/llvm/test/CodeGen/SBF/many_args_new_conv.ll
@@ -2,7 +2,7 @@
 ; RUN: llc -mtriple=sbpfv1-solana-solana < %s | FileCheck %s
 ; RUN: llc -march=sbf -mcpu=v1 -mattr=+mem-encoding < %s | FileCheck %s
 ; RUN: llc -march=sbf -mcpu=v3 < %s | FileCheck --check-prefixes=CHECK-V3,CHECK-V3-OPT %s
-; RUN: llc -O0 -march=sbf -mcpu=v3 < %s | FileCheck --check-prefixes=CHECK-V3,CHECK-V3-OPTNONE %s
+; RUN: llc -O0 -march=sbf -mcpu=v3 < %s | FileCheck --check-prefixes=CHECK-V3 %s
 
 ; Function Attrs: nounwind uwtable
 define i32 @caller_no_alloca(i32 %a, i32 %b, i32 %c) #0 {
@@ -24,8 +24,7 @@ entry:
 ; CHECK-V3: stdw [r10 + 16], 50
 ; CHECK-V3: stdw [r10 + 8], 4
 ; CHECK-V3: stdw [r10 + 0], 3
-; CHECK-V3-OPT-NOT: mov64 r5, r10
-; CHECK-V3-OPTNONE: mov64 r5, r10
+; CHECK-V3-NOT: mov64 r5, r10
 
 ; CHECK: mov64 r4, 1
 ; CHECK: mov64 r5, 2
@@ -68,8 +67,7 @@ define i32 @caller_alloca(i32 %a, i32 %b, i32 %c) #0 {
 ; CHECK-V3: stdw [r10 + 8], 4
 ; Offset in the callee: -frame_size + 0
 ; CHECK-V3: stdw [r10 + 0], 3
-; CHECK-V3-OPT-NOT: mov64 r5, r10
-; CHECK-V3-OPTNONE: mov64 r5, r10
+; CHECK-V3-NOT: mov64 r5, r10
 
 ; CHECK: mov64 r4, 1
 ; CHECK: mov64 r5, 2


### PR DESCRIPTION
The `LowerCall` method uses `getHasDynamicFrames` to distinguish between SBPFv0 and v3 when it should be using `getHasNoStackGaps`. This causes a redundant `mov64 r5, r10` instruction to be emitted for every SBPFv3 call with more than 5 arguments, even though it can be optimized out if optimization is enabled.